### PR TITLE
send fluid where they were needed, not first tank ever visited

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = space
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/src/main/java/logisticspipes/logisticspipes/IAdjacentWorldAccess.java
+++ b/src/main/java/logisticspipes/logisticspipes/IAdjacentWorldAccess.java
@@ -1,17 +1,17 @@
 package logisticspipes.logisticspipes;
 
-import java.util.LinkedList;
+import java.util.List;
 
 import logisticspipes.utils.AdjacentTile;
 
 /**
  * This interface gives access to the surrounding world
- * 
+ *
  * @author Krapht
  */
 public interface IAdjacentWorldAccess {
 
-	public LinkedList<AdjacentTile> getConnectedEntities();
+	public List<AdjacentTile> getConnectedEntities();
 
 	public int getRandomInt(int maxSize);
 }

--- a/src/main/java/logisticspipes/logisticspipes/PipeTransportLayer.java
+++ b/src/main/java/logisticspipes/logisticspipes/PipeTransportLayer.java
@@ -1,6 +1,7 @@
 package logisticspipes.logisticspipes;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
 
 import logisticspipes.pipes.basic.CoreRoutedPipe;
 import logisticspipes.proxy.SimpleServiceLocator;
@@ -11,7 +12,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 /**
  * This class is responsible for handling incoming items for standard pipes
- * 
+ *
  * @author Krapht
  */
 public class PipeTransportLayer extends TransportLayer {
@@ -32,8 +33,8 @@ public class PipeTransportLayer extends TransportLayer {
 			_trackStatistics.recievedItem(item.getItemIdentifierStack().getStackSize());
 		}
 
-		LinkedList<AdjacentTile> adjacentEntities = _worldAccess.getConnectedEntities();
-		LinkedList<ForgeDirection> possibleForgeDirection = new LinkedList<ForgeDirection>();
+		List<AdjacentTile> adjacentEntities = _worldAccess.getConnectedEntities();
+		List<ForgeDirection> possibleForgeDirection = new ArrayList<>();
 
 		// 1st prio, deliver to adjacent IInventories
 

--- a/src/main/java/logisticspipes/pipes/PipeFluidExtractor.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidExtractor.java
@@ -1,6 +1,6 @@
 package logisticspipes.pipes;
 
-import java.util.LinkedList;
+import java.util.List;
 
 import logisticspipes.proxy.SimpleServiceLocator;
 import logisticspipes.textures.Textures;
@@ -32,7 +32,7 @@ public class PipeFluidExtractor extends PipeFluidInsertion {
 		if (!isNthTick(10)) {
 			return;
 		}
-		LinkedList<AdjacentTile> connected = getConnectedEntities();
+		List<AdjacentTile> connected = getConnectedEntities();
 		for (AdjacentTile tile : connected) {
 			if (tile.tile instanceof IFluidHandler && SimpleServiceLocator.pipeInformationManager.isNotAPipe(tile.tile)) {
 				extractFrom((IFluidHandler) tile.tile, tile.orientation);

--- a/src/main/java/logisticspipes/pipes/PipeFluidSupplierMk2.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidSupplierMk2.java
@@ -1,8 +1,8 @@
 package logisticspipes.pipes;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import gnu.trove.iterator.TObjectIntIterator;
+import gnu.trove.map.TObjectIntMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
 
 import logisticspipes.LogisticsPipes;
 import logisticspipes.interfaces.routing.IRequestFluid;
@@ -28,6 +28,7 @@ import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
 
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
@@ -97,15 +98,47 @@ public class PipeFluidSupplierMk2 extends FluidRoutedPipe implements IRequestFlu
 	}
 
 	//from PipeFluidSupplierMk2
-	private ItemIdentifierInventory dummyInventory = new ItemIdentifierInventory(1, "Fluid to keep stocked", 127, true);
+	private final ItemIdentifierInventory dummyInventory = new ItemIdentifierInventory(1, "Fluid to keep stocked", 127, true);
 	private int amount = 0;
 
-	private final Map<FluidIdentifier, Integer> _requestedItems = new HashMap<FluidIdentifier, Integer>();
+	private final TObjectIntMap<FluidIdentifier> _requestedItems = new TObjectIntHashMap<>(8, 0.5f, -1);
 
 	private boolean _requestPartials = false;
 	private MinMode _bucketMinimum = MinMode.ONEBUCKET;
 
 	@Override
+	protected void fillSide(FluidStack toFill, ForgeDirection tankLocation, IFluidHandler tile) {
+		if (dummyInventory.getStackInSlot(0) == null)
+			// shouldn't happen, but ok
+			return;
+		// check if this tank need more fluid
+		int have = 0;
+		FluidIdentifier fIdent = FluidIdentifier.get(dummyInventory.getIDStackInSlot(0).getItem());
+		for (FluidTankInfo info : tile.getTankInfo(ForgeDirection.UNKNOWN)) {
+			if (info.fluid != null && fIdent.equals(FluidIdentifier.get(info.fluid)))
+				have += info.fluid.amount;
+		}
+		int vacant = amount - have;
+		if (vacant <= 0)
+			// too much fluid..
+			return;
+		// we can't actually be too strict with checking here. maybe the tank is being drained by
+		// another party faster than LP can sustain.
+		// the check to send fluid request does not run every tick after all...
+		// so we just check if minimum is reached
+		if (_bucketMinimum.getAmount() != 0 && vacant < _bucketMinimum.getAmount()) {
+			// not enough spare space - this packet must be for tank on different side
+			return;
+		}
+		// attempt to fill now... don't fill too much though
+		// if insertion on all sides failed, surplus will end up in one of the internal pipe tanks
+		// it won't be wasted
+		FluidStack filled = toFill.copy();
+		filled.amount = Math.min(filled.amount, vacant);
+		toFill.amount -= tile.fill(tankLocation.getOpposite(), filled, true);
+	}
+
+    @Override
 	public void throttledUpdateEntity() {
 		if (!isEnabled()) {
 			return;
@@ -117,6 +150,13 @@ public class PipeFluidSupplierMk2 extends FluidRoutedPipe implements IRequestFlu
 		if (dummyInventory.getStackInSlot(0) == null) {
 			return;
 		}
+
+		TObjectIntMap<FluidIdentifier> requestDiscount = new TObjectIntHashMap<>(_requestedItems);
+		FluidTank centerTank = ((PipeFluidTransportLogistics) transport).internalTank;
+		if (centerTank != null && centerTank.getFluid() != null) {
+			requestDiscount.adjustOrPutValue(FluidIdentifier.get(centerTank.getFluid()), centerTank.getFluid().amount, centerTank.getFluid().amount);
+		}
+
 		WorldUtil worldUtil = new WorldUtil(getWorld(), getX(), getY(), getZ());
 		for (AdjacentTile tile : worldUtil.getAdjacentTileEntities(true)) {
 			if (!(tile.tile instanceof IFluidHandler) || SimpleServiceLocator.pipeInformationManager.isItemPipe(tile.tile)) {
@@ -127,72 +167,50 @@ public class PipeFluidSupplierMk2 extends FluidRoutedPipe implements IRequestFlu
 				continue;
 			}
 
-			//How much do I want?
-			Map<FluidIdentifier, Integer> wantFluids = new HashMap<FluidIdentifier, Integer>();
+			// How much should I request?
+            TObjectIntMap<FluidIdentifier> wantFluids = new TObjectIntHashMap<>(8);
 			FluidIdentifier fIdent = FluidIdentifier.get(dummyInventory.getIDStackInSlot(0).getItem());
 			wantFluids.put(fIdent, amount);
 
-			//How much do I have?
-			HashMap<FluidIdentifier, Integer> haveFluids = new HashMap<FluidIdentifier, Integer>();
-
 			FluidTankInfo[] result = container.getTankInfo(ForgeDirection.UNKNOWN);
 			for (FluidTankInfo slot : result) {
-				if (slot == null || slot.fluid == null || slot.fluid.getFluidID() == 0 || !wantFluids.containsKey(FluidIdentifier.get(slot.fluid))) {
+				if (slot == null || slot.fluid == null || slot.fluid.getFluidID() == 0) {
 					continue;
 				}
-				Integer liquidWant = haveFluids.get(FluidIdentifier.get(slot.fluid));
-				if (liquidWant == null) {
-					haveFluids.put(FluidIdentifier.get(slot.fluid), slot.fluid.amount);
-				} else {
-					haveFluids.put(FluidIdentifier.get(slot.fluid), liquidWant + slot.fluid.amount);
-				}
+                wantFluids.adjustValue(FluidIdentifier.get(slot.fluid), -slot.fluid.amount);
 			}
 
 			//What does our sided internal tank have
 			if (tile.orientation.ordinal() < ((PipeFluidTransportLogistics) transport).sideTanks.length) {
-				FluidTank centerTank = ((PipeFluidTransportLogistics) transport).sideTanks[tile.orientation.ordinal()];
-				if (centerTank != null && centerTank.getFluid() != null && wantFluids.containsKey(FluidIdentifier.get(centerTank.getFluid()))) {
-					Integer liquidWant = haveFluids.get(FluidIdentifier.get(centerTank.getFluid()));
-					if (liquidWant == null) {
-						haveFluids.put(FluidIdentifier.get(centerTank.getFluid()), centerTank.getFluid().amount);
-					} else {
-						haveFluids.put(FluidIdentifier.get(centerTank.getFluid()), liquidWant + centerTank.getFluid().amount);
-					}
+				FluidTank sideTank = ((PipeFluidTransportLogistics) transport).sideTanks[tile.orientation.ordinal()];
+				if (sideTank != null && sideTank.getFluid() != null) {
+                    wantFluids.adjustValue(FluidIdentifier.get(sideTank.getFluid()), -sideTank.getFluid().amount);
 				}
 			}
 
-			//What does our center internal tank have
-			FluidTank centerTank = ((PipeFluidTransportLogistics) transport).internalTank;
-			if (centerTank != null && centerTank.getFluid() != null && wantFluids.containsKey(FluidIdentifier.get(centerTank.getFluid()))) {
-				Integer liquidWant = haveFluids.get(FluidIdentifier.get(centerTank.getFluid()));
-				if (liquidWant == null) {
-					haveFluids.put(FluidIdentifier.get(centerTank.getFluid()), centerTank.getFluid().amount);
-				} else {
-					haveFluids.put(FluidIdentifier.get(centerTank.getFluid()), liquidWant + centerTank.getFluid().amount);
-				}
-			}
+			// drop entries that already have enough in it
+			wantFluids.retainEntries((k, v) -> v >= 0);
 
-			//HashMap<Integer, Integer> needFluids = new HashMap<Integer, Integer>();
-			//Reduce what I have and what have been requested already
-			for (Entry<FluidIdentifier, Integer> liquidId : wantFluids.entrySet()) {
-				Integer haveCount = haveFluids.get(liquidId.getKey());
-				if (haveCount != null) {
-					liquidId.setValue(liquidId.getValue() - haveCount);
-				}
-				for (Entry<FluidIdentifier, Integer> requestedItem : _requestedItems.entrySet()) {
-					if (requestedItem.getKey().equals(liquidId.getKey())) {
-						liquidId.setValue(liquidId.getValue() - requestedItem.getValue());
-					}
-				}
-			}
+			// Reduce what have been requested already
+            for (TObjectIntIterator<FluidIdentifier> iter = requestDiscount.iterator(); iter.hasNext(); ) {
+                iter.advance();
+                wantFluids.adjustValue(iter.key(), -iter.value());
+				iter.remove();
+            }
 
 			setRequestFailed(false);
 
 			//Make request
 
-			for (FluidIdentifier need : wantFluids.keySet()) {
-				int countToRequest = wantFluids.get(need);
-				if (countToRequest < 1) {
+            for (TObjectIntIterator<FluidIdentifier> iter = wantFluids.iterator(); iter.hasNext();) {
+                iter.advance();
+                FluidIdentifier need = iter.key();
+                int countToRequest = iter.value();
+				if (countToRequest == 0) {
+					continue;
+				} else if (countToRequest < 0) {
+					// at this point a negative value can only come from requestDiscount, so add it back
+					requestDiscount.adjustOrPutValue(need, -countToRequest, -countToRequest);
 					continue;
 				}
 				if (_bucketMinimum.getAmount() != 0 && countToRequest < _bucketMinimum.getAmount()) {
@@ -215,12 +233,7 @@ public class PipeFluidSupplierMk2 extends FluidRoutedPipe implements IRequestFlu
 				}
 
 				if (success) {
-					Integer currentRequest = _requestedItems.get(need);
-					if (currentRequest == null) {
-						_requestedItems.put(need, countToRequest);
-					} else {
-						_requestedItems.put(need, currentRequest + countToRequest);
-					}
+					_requestedItems.adjustOrPutValue(need, countToRequest, countToRequest);
 				} else {
 					setRequestFailed(true);
 				}
@@ -248,28 +261,17 @@ public class PipeFluidSupplierMk2 extends FluidRoutedPipe implements IRequestFlu
 
 	private void decreaseRequested(FluidIdentifier liquid, int remaining) {
 		//see if we can get an exact match
-		Integer count = _requestedItems.get(liquid);
-		if (count != null) {
-			_requestedItems.put(liquid, Math.max(0, count - remaining));
-			remaining -= count;
-		}
-		if (remaining <= 0) {
-			return;
-		}
-		//still remaining... was from fuzzyMatch on a crafter
-		for (Entry<FluidIdentifier, Integer> e : _requestedItems.entrySet()) {
-			if (e.getKey().equals(liquid)) {
-				int expected = e.getValue();
-				e.setValue(Math.max(0, expected - remaining));
-				remaining -= expected;
-			}
-			if (remaining <= 0) {
-				return;
-			}
-		}
-		//we have no idea what this is, log it.
-		debug.log("liquid supplier got unexpected item " + liquid.toString());
-	}
+		int count = _requestedItems.get(liquid);
+        if (count <= 0) return;
+        if (count <= remaining)
+            _requestedItems.remove(liquid);
+        else
+            _requestedItems.put(liquid, count - remaining);
+        if (remaining > count) {
+            //we have no idea what this is, log it.
+            debug.log("liquid supplier got unexpected item " + liquid.toString());
+        }
+    }
 
 	@Override
 	public void liquidLost(FluidIdentifier item, int amount) {

--- a/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Krapht, 2011
- * 
+ *
  * "LogisticsPipes" is distributed under the terms of the Minecraft Mod Public
  * License 1.0, or MMPL. Please check the contents of the license located in
  * http://www.mod-buildcraft.com/MMPL-1.0.txt
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -314,7 +313,7 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe implements IClient
 	/**
 	 * Designed to help protect against routing loops - if both pipes are on the
 	 * same block, and of ISided overlapps, return true
-	 * 
+	 *
 	 * @param other
 	 * @return boolean indicating if both pull from the same inventory.
 	 */
@@ -968,20 +967,15 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe implements IClient
 		}
 	}
 
-	/*** -- IAdjacentWorldAccess -- ***/
+	/*** -- IAdjacentWorldAccess --
+     * @return***/
 
 	@Override
-	public LinkedList<AdjacentTile> getConnectedEntities() {
+	public List<AdjacentTile> getConnectedEntities() {
 		WorldUtil world = new WorldUtil(getWorld(), getX(), getY(), getZ());
-		LinkedList<AdjacentTile> adjacent = world.getAdjacentTileEntities(true);
+		List<AdjacentTile> adjacent = world.getAdjacentTileEntities(true);
 
-		Iterator<AdjacentTile> iterator = adjacent.iterator();
-		while (iterator.hasNext()) {
-			AdjacentTile tile = iterator.next();
-			if (!MainProxy.checkPipesConnections(container, tile.tile, tile.orientation)) {
-				iterator.remove();
-			}
-		}
+        adjacent.removeIf(tile -> !MainProxy.checkPipesConnections(container, tile.tile, tile.orientation));
 
 		return adjacent;
 	}
@@ -1330,7 +1324,7 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe implements IClient
 	/**
 	 * used as a distance offset when deciding which pipe to use NOTE: called
 	 * very regularly, returning a pre-calculated int is probably appropriate.
-	 * 
+	 *
 	 * @return
 	 */
 	public double getLoadFactor() {

--- a/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
@@ -3,7 +3,6 @@ package logisticspipes.pipes.basic;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 
 import buildcraft.api.transport.IPipeConnection;
@@ -303,7 +302,7 @@ public class LogisticsTileGenericPipe extends TileEntity implements IOCTile, ILP
 		blockNeighborChange = true;
 		boolean connected[] = new boolean[6];
 		WorldUtil world = new WorldUtil(getWorld(), xCoord, yCoord, zCoord);
-		LinkedList<AdjacentTile> adjacent = world.getAdjacentTileEntities(false);
+		List<AdjacentTile> adjacent = world.getAdjacentTileEntities(false);
 		for (AdjacentTile aTile : adjacent) {
 			if (SimpleServiceLocator.ccProxy.isTurtle(aTile.tile)) {
 				connected[aTile.orientation.ordinal()] = true;

--- a/src/main/java/logisticspipes/pipes/basic/PowerSupplierHandler.java
+++ b/src/main/java/logisticspipes/pipes/basic/PowerSupplierHandler.java
@@ -1,6 +1,5 @@
 package logisticspipes.pipes.basic;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import logisticspipes.blocks.powertile.LogisticsPowerProviderTileEntity;
@@ -46,7 +45,7 @@ public class PowerSupplierHandler {
 		if (SimpleServiceLocator.cofhPowerProxy.isAvailable() && pipe.getUpgradeManager().hasRFPowerSupplierUpgrade()) {
 			//Use Buffer
 			WorldUtil worldUtil = new WorldUtil(pipe.getWorld(), pipe.getX(), pipe.getY(), pipe.getZ());
-			LinkedList<AdjacentTile> adjacent = worldUtil.getAdjacentTileEntities(false);
+			List<AdjacentTile> adjacent = worldUtil.getAdjacentTileEntities(false);
 			float globalNeed = 0;
 			float[] need = new float[adjacent.size()];
 			int i = 0;
@@ -128,7 +127,7 @@ public class PowerSupplierHandler {
 		if (SimpleServiceLocator.IC2Proxy.hasIC2() && pipe.getUpgradeManager().getIC2PowerLevel() > 0) {
 			//Use Buffer
 			WorldUtil worldUtil = new WorldUtil(pipe.getWorld(), pipe.getX(), pipe.getY(), pipe.getZ());
-			LinkedList<AdjacentTile> adjacent = worldUtil.getAdjacentTileEntities(false);
+			List<AdjacentTile> adjacent = worldUtil.getAdjacentTileEntities(false);
 			float globalNeed = 0;
 			float[] need = new float[adjacent.size()];
 			int i = 0;

--- a/src/main/java/logisticspipes/pipes/basic/fluid/FluidRoutedPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/fluid/FluidRoutedPipe.java
@@ -245,8 +245,7 @@ public abstract class FluidRoutedPipe extends CoreRoutedPipe {
 					Pair<TileEntity, ForgeDirection> pair = adjTanks.get(i);
 					IFluidHandler tank = (IFluidHandler) pair.getValue1();
 					ForgeDirection dir = pair.getValue2();
-					filled = tank.fill(dir.getOpposite(), liquid.copy(), true);
-					liquid.amount -= filled;
+					fillSide(liquid, dir, tank);
 					if (liquid.amount != 0) {
 						continue;
 					}
@@ -281,6 +280,10 @@ public abstract class FluidRoutedPipe extends CoreRoutedPipe {
 			return true;
 		}
 		return false;
+	}
+
+	protected void fillSide(FluidStack toFill, ForgeDirection tankLocation, IFluidHandler tile) {
+		toFill.amount -= tile.fill(tankLocation.getOpposite(), toFill.copy(), true);
 	}
 
 	@Override

--- a/src/main/java/logisticspipes/utils/WorldUtil.java
+++ b/src/main/java/logisticspipes/utils/WorldUtil.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Krapht, 2011
- * 
+ *
  * "LogisticsPipes" is distributed under the terms of the Minecraft Mod Public
  * License 1.0, or MMPL. Please check the contents of the license located in
  * http://www.mod-buildcraft.com/MMPL-1.0.txt
@@ -8,7 +8,8 @@
 
 package logisticspipes.utils;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
 
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.proxy.SimpleServiceLocator;
@@ -41,12 +42,12 @@ public class WorldUtil {
 		_z = tile.zCoord;
 	}
 
-	public LinkedList<AdjacentTile> getAdjacentTileEntities() {
+	public List<AdjacentTile> getAdjacentTileEntities() {
 		return getAdjacentTileEntities(false);
 	}
 
-	public LinkedList<AdjacentTile> getAdjacentTileEntities(boolean flag) {
-		LinkedList<AdjacentTile> foundTiles = new LinkedList<AdjacentTile>();
+	public List<AdjacentTile> getAdjacentTileEntities(boolean flag) {
+		ArrayList<AdjacentTile> foundTiles = new ArrayList<>(6);
 		TileEntity tilePipe = null;
 		if (flag) {
 			tilePipe = _worldObj.getTileEntity(_x, _y, _z);


### PR DESCRIPTION
Assume one fluid supplier is connected to two fluid tanks with capacity of 4 buckets, both is empty. If it is set to maintain 1 bucket of water, it will request 1 bucket of water, 1 for each tank. When the fluid arrives, it will be filled into one of these tanks (call it tank A). Then the pipe supplier see one of the tank (call it tank B) still doesn't have enough fluid, so it will request 1 more bucket of water. However, when this packet arrives, it will still be sent to the tank A. This process will repeat until A is completely filled, then B will start to accept fluid.

With this change, the first request will be 2 packet of 1 bucket of water, which will be evenly distributed to tank A and B upon arrivial. 