### PR TITLE
Fix broken gradle tokens from the previous buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1646409286
+//version: 1650343995
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -568,7 +568,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ developmentEnvironmentUserName = Developer
 # The string's content will be replaced with your mods version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...])
 # Leave these properties empty to skip individual token replacements
-replaceGradleTokenInFile = LogisticsPipes.java
+replaceGradleTokenInFile = LPConstants.java
 gradleTokenModId =
 gradleTokenModName =
 gradleTokenVersion = GRADLETOKEN_VERSION

--- a/src/main/java/logisticspipes/LPConstants.java
+++ b/src/main/java/logisticspipes/LPConstants.java
@@ -12,10 +12,10 @@ public class LPConstants {
 	public static final float BC_PIPE_MIN_POS = 0.25F;
 	public static final float BC_PIPE_MAX_POS = 0.75F;
 
-	public static final boolean DEBUG = "%DEBUG%".equals("%" + "DEBUG" + "%") || "%DEBUG%".equals("true");
-	public static final String MCVersion = "%MCVERSION%";
-	public static final String VERSION = "%VERSION%:%DEBUG%";
-	public static final boolean DEV_BUILD = LPConstants.VERSION.contains(".dev.") || LPConstants.DEBUG;
+	public static final boolean DEBUG = false;
+	public static final String MCVersion = "1.7.10";
+	public static final String VERSION = "GRADLETOKEN_VERSION";
+	public static final boolean DEV_BUILD = false;
 
 	public static int pipeModel = -1;
 	public static int solidBlockModel = -1;

--- a/src/main/java/logisticspipes/LogisticsPipes.java
+++ b/src/main/java/logisticspipes/LogisticsPipes.java
@@ -160,7 +160,7 @@ import org.apache.logging.log4j.Logger;
 @Mod(
 		modid = "LogisticsPipes",
 		name = "Logistics Pipes",
-		version = "GRADLETOKEN_VERSION",
+		version = LPConstants.VERSION,
 		/* %------------CERTIFICATE-SUM-----------% */
 		dependencies = "required-after:Forge@[10.12.1.1079,);" +
 				"required-after:BuildCraft|Core;" +


### PR DESCRIPTION
The old buildscript replaced some tokens in LPConstants.java, which now aren't replaced and cause LP to always build in debug mode. Here I replace them with the same values they would get in a normal build.