### PR TITLE
Fix drag-and-drop not working

### DIFF
--- a/src/main/java/logisticspipes/utils/gui/ColorSlot.java
+++ b/src/main/java/logisticspipes/utils/gui/ColorSlot.java
@@ -3,6 +3,7 @@ package logisticspipes.utils.gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
 
 public class ColorSlot extends Slot {
 
@@ -12,6 +13,11 @@ public class ColorSlot extends Slot {
 
     public ColorSlot(Slot slot) {
         super(slot.inventory, slot.getSlotIndex(), slot.xDisplayPosition, slot.yDisplayPosition);
+    }
+
+    @Override
+    public boolean isItemValid(ItemStack p_75214_1_) {
+        return false;
     }
 
     @Override

--- a/src/main/java/logisticspipes/utils/gui/DummySlot.java
+++ b/src/main/java/logisticspipes/utils/gui/DummySlot.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
 
 public class DummySlot extends Slot {
 
@@ -21,6 +22,11 @@ public class DummySlot extends Slot {
 
     public DummySlot(IInventory iinventory, int i, int j, int k) {
         super(iinventory, i, j, k);
+    }
+
+    @Override
+    public boolean isItemValid(ItemStack p_75214_1_) {
+        return false;
     }
 
     @Override

--- a/src/main/java/logisticspipes/utils/gui/FluidSlot.java
+++ b/src/main/java/logisticspipes/utils/gui/FluidSlot.java
@@ -3,6 +3,7 @@ package logisticspipes.utils.gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
 
 public class FluidSlot extends Slot {
 
@@ -12,6 +13,11 @@ public class FluidSlot extends Slot {
 
     public FluidSlot(Slot slot) {
         super(slot.inventory, slot.getSlotIndex(), slot.xDisplayPosition, slot.yDisplayPosition);
+    }
+
+    @Override
+    public boolean isItemValid(ItemStack p_75214_1_) {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Address issue arose in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11531#issuecomment-1270616235
It was not problem before as `handleGUIContainerClick` was called before `handleCheatItemClick` (see https://github.com/GTNewHorizons/NotEnoughItems/commit/91e9b2a5aed49808989f006f632a8c33f77bf941#diff-3165dfdbdb551010e96ec8d8bac129044b653b086bc2a1a01410b427fbd42a8a). Now `CheatItemHandler` is registered and called earlier than `LogisticsBaseGuiScreen`, so issue happened.