### PR TITLE
Remove useless & heavy render re-caching for tiles that are too far

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,21 +2,21 @@
 
 dependencies {
 	api('com.github.GTNewHorizons:BuildCraft:7.1.39:dev')
-	implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.71:dev')
-	implementation('com.github.GTNewHorizons:NotEnoughItems:2.5.19-GTNH:dev')
+	implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.104:dev')
+	implementation('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev')
 
-	compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:api') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-325-GTNH:api') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:StorageDrawers:1.13.3-GTNH:api') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:OpenComputers:1.10.7-GTNH:api') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-342-GTNH:api') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:StorageDrawers:1.13.4-GTNH:api') { transitive = false }
 	compileOnly('com.github.GTNewHorizons:Jabba:1.3.2:dev') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:ironchest:6.0.75:dev') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:ForestryMC:4.8.4:dev') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:EnderIO:2.6.6:dev') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:EnderCore:0.3.1:dev') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:ironchest:6.0.82:dev') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:ForestryMC:4.8.7:dev') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:EnderIO:2.7.1:dev') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:EnderCore:0.4.6:dev') { transitive = false }
 	compileOnly('com.github.GTNewHorizons:EnderStorage:1.5.0:dev') { transitive = false }
 	compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.34:api') { transitive = false }
 	compileOnly('com.github.GTNewHorizons:Binnie:2.3.3:dev') { transitive = false }
-	compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.71:dev') { transitive = false }
+	compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.104:dev') { transitive = false }
 
 	compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev') { transitive = false }
 	compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') { transitive = false }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
@@ -728,64 +728,65 @@ public class LogisticsNewRenderPipe {
             renderState.renderList = null;
         }
 
-        if (renderState.renderList == null) {
-            renderState.renderList = SimpleServiceLocator.renderListHandler.getNewRenderList();
-        }
-
         if (distance > config.getRenderPipeDistance() * config.getRenderPipeDistance()) {
             if (config.isUseFallbackRenderer()) {
                 renderState.forceRenderOldPipe = true;
             }
-        } else {
-            renderState.forceRenderOldPipe = false;
-            boolean recalculateList = false;
-            if (renderState.cachedRenderer == null) {
-                List<Pair<IModel3D, I3DOperation[]>> objectsToRender = new ArrayList<>();
-                fillObjectsToRenderList(objectsToRender, pipeTile, renderState);
-                renderState.cachedRenderer = objectsToRender;
-                recalculateList = true;
-            }
-            if (!renderState.renderList.isFilled() || recalculateList) {
-                renderState.renderList.startListCompile();
+            return;
+        }
 
-                Tessellator tess = Tessellator.instance;
+        if (renderState.renderList == null) {
+            renderState.renderList = SimpleServiceLocator.renderListHandler.getNewRenderList();
+        }
 
-                SimpleServiceLocator.cclProxy.getRenderState().reset();
-                SimpleServiceLocator.cclProxy.getRenderState().setUseNormals(true);
-                SimpleServiceLocator.cclProxy.getRenderState().setAlphaOverride(0xff);
+        renderState.forceRenderOldPipe = false;
+        boolean recalculateList = false;
+        if (renderState.cachedRenderer == null) {
+            List<Pair<IModel3D, I3DOperation[]>> objectsToRender = new ArrayList<>();
+            fillObjectsToRenderList(objectsToRender, pipeTile, renderState);
+            renderState.cachedRenderer = objectsToRender;
+            recalculateList = true;
+        }
+        if (!renderState.renderList.isFilled() || recalculateList) {
+            renderState.renderList.startListCompile();
 
-                int brightness = new LPPosition((TileEntity) pipeTile).getBlock(pipeTile.getWorldObj())
-                        .getMixedBrightnessForBlock(
-                                pipeTile.getWorldObj(),
-                                pipeTile.xCoord,
-                                pipeTile.yCoord,
-                                pipeTile.zCoord);
+            Tessellator tess = Tessellator.instance;
 
-                tess.setColorOpaque_F(1F, 1F, 1F);
-                tess.setBrightness(brightness);
+            SimpleServiceLocator.cclProxy.getRenderState().reset();
+            SimpleServiceLocator.cclProxy.getRenderState().setUseNormals(true);
+            SimpleServiceLocator.cclProxy.getRenderState().setAlphaOverride(0xff);
 
-                tess.startDrawingQuads();
-                for (Pair<IModel3D, I3DOperation[]> model : renderState.cachedRenderer) {
-                    if (model == null) {
-                        SimpleServiceLocator.cclProxy.getRenderState().setAlphaOverride(0xa0);
-                    } else {
-                        model.getValue1().render(model.getValue2());
-                    }
+            int brightness = new LPPosition((TileEntity) pipeTile).getBlock(pipeTile.getWorldObj())
+                    .getMixedBrightnessForBlock(
+                            pipeTile.getWorldObj(),
+                            pipeTile.xCoord,
+                            pipeTile.yCoord,
+                            pipeTile.zCoord);
+
+            tess.setColorOpaque_F(1F, 1F, 1F);
+            tess.setBrightness(brightness);
+
+            tess.startDrawingQuads();
+            for (Pair<IModel3D, I3DOperation[]> model : renderState.cachedRenderer) {
+                if (model == null) {
+                    SimpleServiceLocator.cclProxy.getRenderState().setAlphaOverride(0xa0);
+                } else {
+                    model.getValue1().render(model.getValue2());
                 }
-                SimpleServiceLocator.cclProxy.getRenderState().setAlphaOverride(0xff);
-                tess.draw();
+            }
+            SimpleServiceLocator.cclProxy.getRenderState().setAlphaOverride(0xff);
+            tess.draw();
 
-                renderState.renderList.stopCompile();
-            }
-            if (renderState.renderList != null) {
-                GL11.glPushMatrix();
-                GL11.glTranslated(x, y, z);
-                GL11.glEnable(GL11.GL_BLEND);
-                GL11.glBlendFunc(GL11.GL_ONE, GL11.GL_ZERO);
-                renderState.renderList.render();
-                GL11.glDisable(GL11.GL_BLEND);
-                GL11.glPopMatrix();
-            }
+            renderState.renderList.stopCompile();
+        }
+        if (renderState.renderList != null) {
+            GL11.glPushMatrix();
+            GL11.glTranslated(x, y, z);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_ONE, GL11.GL_ZERO);
+            renderState.renderList.render();
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glPopMatrix();
         }
     }
 


### PR DESCRIPTION
LP have renderState.renderList.
For tiles which are too far away, renderList is deleted after 60 seconds of not being used.
However in previous logic, it was then recalculated even if it's not used by those tiles which are far away, which creates useless and heavy rebuilding every time. 

Commit makes it so that if tile is too far, the renderlist will not be re-created until the tile is going to be rendered