### PR TITLE
cleanup: Remove unused LPTickHandler.adjChecksDone

### DIFF
--- a/src/main/java/logisticspipes/routing/ServerRouter.java
+++ b/src/main/java/logisticspipes/routing/ServerRouter.java
@@ -49,7 +49,6 @@ import logisticspipes.request.resources.FluidResource;
 import logisticspipes.request.resources.IResource;
 import logisticspipes.request.resources.ItemResource;
 import logisticspipes.routing.pathfinder.PathFinder;
-import logisticspipes.ticks.LPTickHandler;
 import logisticspipes.ticks.RoutingTableUpdateThread;
 import logisticspipes.utils.CacheHolder;
 import logisticspipes.utils.OneList;
@@ -489,7 +488,6 @@ public class ServerRouter implements IRouter, Comparable<ServerRouter> {
             getPipe().spawnParticle(Particles.LightRedParticle, 5);
         }
 
-        LPTickHandler.adjChecksDone++;
         boolean adjacentChanged = false;
         CoreRoutedPipe thisPipe = getPipe();
         if (thisPipe == null) {

--- a/src/main/java/logisticspipes/ticks/LPTickHandler.java
+++ b/src/main/java/logisticspipes/ticks/LPTickHandler.java
@@ -27,8 +27,6 @@ import lombok.Setter;
 
 public class LPTickHandler {
 
-    public static int adjChecksDone = 0;
-
     @SubscribeEvent
     public void clientTick(ClientTickEvent event) {
         FluidIdentifier.initFromForge(true);
@@ -43,7 +41,6 @@ public class LPTickHandler {
         SimpleServiceLocator.craftingPermissionManager.tick();
         SimpleServiceLocator.serverBufferHandler.serverTick(event);
         MainProxy.proxy.tickServer();
-        LPTickHandler.adjChecksDone = 0;
         DebugGuiController.instance().execServer();
     }
 


### PR DESCRIPTION
According to `git log -S adjChecksDone` the field was introduced with commit 56aff51c0796b751185e123d051a5b456148db6d but never actually read.