### PR TITLE
refactor: Cache two reflected BC render methods directly in a new BCRenderTESR class

### DIFF
--- a/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
@@ -1,0 +1,41 @@
+package logisticspipes.proxy.buildcraft;
+
+import java.lang.reflect.Method;
+
+import buildcraft.transport.TileGenericPipe;
+import buildcraft.transport.render.PipeRendererTESR;
+import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+import logisticspipes.proxy.buildcraft.subproxies.IBCRenderTESR;
+import lombok.SneakyThrows;
+
+public class BCRenderTESR implements IBCRenderTESR {
+
+    private final Method renderGatesWires;
+    private final Method renderPluggables;
+
+    @SneakyThrows(Exception.class)
+    BCRenderTESR() {
+        renderGatesWires = PipeRendererTESR.class.getDeclaredMethod(
+                "renderGatesWires",
+                new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
+        renderGatesWires.setAccessible(true);
+        renderPluggables = PipeRendererTESR.class.getDeclaredMethod(
+                "renderPluggables",
+                new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
+        renderPluggables.setAccessible(true);
+    }
+
+    @Override
+    @SneakyThrows(Exception.class)
+    public void renderWires(LogisticsTileGenericPipe pipe, double x, double y, double z) {
+        TileGenericPipe tgPipe = (TileGenericPipe) pipe.tilePart.getOriginal();
+        renderGatesWires.invoke(PipeRendererTESR.INSTANCE, tgPipe, x, y, z);
+    }
+
+    @Override
+    @SneakyThrows(Exception.class)
+    public void dynamicRenderPluggables(LogisticsTileGenericPipe pipe, double x, double y, double z) {
+        TileGenericPipe tgPipe = (TileGenericPipe) pipe.tilePart.getOriginal();
+        renderPluggables.invoke(PipeRendererTESR.INSTANCE, tgPipe, x, y, z);
+    }
+}

--- a/src/main/java/logisticspipes/proxy/buildcraft/BuildCraftProxy.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BuildCraftProxy.java
@@ -12,6 +12,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import buildcraft.BuildCraftCore;
@@ -31,6 +32,7 @@ import buildcraft.api.transport.IPipeConnection;
 import buildcraft.api.transport.IPipeTile;
 import buildcraft.api.transport.IPipeTile.PipeType;
 import buildcraft.core.ItemMapLocation;
+import buildcraft.core.Version;
 import buildcraft.core.lib.ITileBufferHolder;
 import buildcraft.robotics.EntityRobot;
 import buildcraft.robotics.ItemRobot;
@@ -43,7 +45,6 @@ import buildcraft.transport.PipeEventBus;
 import buildcraft.transport.PipeTransportFluids;
 import buildcraft.transport.PipeTransportItems;
 import buildcraft.transport.TileGenericPipe;
-import buildcraft.transport.render.PipeRendererTESR;
 import buildcraft.transport.render.PipeTransportItemsRenderer;
 import buildcraft.transport.render.PipeTransportRenderer;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -78,7 +79,6 @@ import logisticspipes.proxy.interfaces.ICraftingParts;
 import logisticspipes.proxy.interfaces.ICraftingRecipeProvider;
 import logisticspipes.transport.PipeFluidTransportLogistics;
 import logisticspipes.utils.ReflectionHelper;
-import lombok.SneakyThrows;
 
 public class BuildCraftProxy implements IBCProxy {
 
@@ -96,7 +96,7 @@ public class BuildCraftProxy implements IBCProxy {
     public BuildCraftProxy() {
         String BCVersion = null;
         try {
-            Field versionField = buildcraft.core.Version.class.getDeclaredField("VERSION");
+            Field versionField = Version.class.getDeclaredField("VERSION");
             BCVersion = (String) versionField.get(null);
         } catch (Exception e) {
             e.printStackTrace();
@@ -279,8 +279,7 @@ public class BuildCraftProxy implements IBCProxy {
     @Override
     public Object getLPPipeType() {
         if (logisticsPipeType == null) {
-            logisticsPipeType = net.minecraftforge.common.util.EnumHelper
-                    .addEnum(PipeType.class, "LOGISTICS", new Class<?>[] {}, new Object[] {});
+            logisticsPipeType = EnumHelper.addEnum(PipeType.class, "LOGISTICS", new Class<?>[] {}, new Object[] {});
         }
         return logisticsPipeType;
     }
@@ -442,8 +441,7 @@ public class BuildCraftProxy implements IBCProxy {
     }
 
     /**
-     * @see buildcraft.robotics.ItemRobot#onItemUse(ItemStack, EntityPlayer, World, int, int, int, int, float, float,
-     *      float)
+     * @see ItemRobot#onItemUse(ItemStack, EntityPlayer, World, int, int, int, int, float, float, float)
      */
     private boolean checkRobot(World world, int x, int y, int z, EntityPlayer player, ItemStack currentItem) {
         if (!world.isRemote) {
@@ -516,34 +514,7 @@ public class BuildCraftProxy implements IBCProxy {
 
     @Override
     public IBCRenderTESR getBCRenderTESR() {
-        return new IBCRenderTESR() {
-
-            @Override
-            @SneakyThrows(Exception.class)
-            public void renderWires(LogisticsTileGenericPipe pipe, double x, double y, double z) {
-                TileGenericPipe tgPipe = (TileGenericPipe) pipe.tilePart.getOriginal();
-                ReflectionHelper.invokePrivateMethod(
-                        Object.class,
-                        PipeRendererTESR.class,
-                        PipeRendererTESR.INSTANCE,
-                        "renderGatesWires",
-                        new Class[] { TileGenericPipe.class, double.class, double.class, double.class },
-                        new Object[] { tgPipe, x, y, z });
-            }
-
-            @Override
-            @SneakyThrows(Exception.class)
-            public void dynamicRenderPluggables(LogisticsTileGenericPipe pipe, double x, double y, double z) {
-                TileGenericPipe tgPipe = (TileGenericPipe) pipe.tilePart.getOriginal();
-                ReflectionHelper.invokePrivateMethod(
-                        Object.class,
-                        PipeRendererTESR.class,
-                        PipeRendererTESR.INSTANCE,
-                        "renderPluggables",
-                        new Class[] { TileGenericPipe.class, double.class, double.class, double.class },
-                        new Object[] { tgPipe, x, y, z });
-            }
-        };
+        return new BCRenderTESR();
     }
 
     @Override


### PR DESCRIPTION
These two methods are invoked a lot of times. This causes the ReflectionHelper [to allocate `Triplet` instance](https://github.com/GTNewHorizons/LogisticsPipes/blob/76917a2f78f2119531b9077b9ca1fde540d38ea1/src/main/java/logisticspipes/utils/ReflectionHelper.java#L21) that serves as a lookup into a method cache. In a local test world the ReflectionHelper created ~4MB of these temporary `Triplet` instances in half a minute or so.

This PR introduces a new `BCRenderTESR` class that implements the same interface but stores the two required private methods as fields. No need to go a roundabout way through a cache with an expensive key.

We don't re-use the existing anonymous class since we need a constructor to initialize the fields.

Side-note: The rest of the changes in  BuildCraftProxy.java come from spotless.