### PR TITLE
refactor: Use ItemIdentifierStack in ItemStackRenderer

### DIFF
--- a/src/main/java/logisticspipes/gui/hud/HudChassisPipe.java
+++ b/src/main/java/logisticspipes/gui/hud/HudChassisPipe.java
@@ -298,7 +298,7 @@ public class HudChassisPipe extends BasicHUDGui {
                         false,
                         shifted,
                         renderInColor);
-                itemStackRenderer.setItemstack(ItemIdentifierStack.getFromStack(module))
+                itemStackRenderer.setItemIdentifierStack(ItemIdentifierStack.getFromStack(module))
                         .setDisplayAmount(DisplayAmount.NEVER);
 
                 itemStackRenderer.renderInGui();

--- a/src/main/java/logisticspipes/gui/hud/HudChassisPipe.java
+++ b/src/main/java/logisticspipes/gui/hud/HudChassisPipe.java
@@ -15,6 +15,7 @@ import logisticspipes.pipes.PipeLogisticsChassi;
 import logisticspipes.utils.gui.GuiGraphics;
 import logisticspipes.utils.gui.hud.BasicHUDButton;
 import logisticspipes.utils.item.ItemIdentifierInventory;
+import logisticspipes.utils.item.ItemIdentifierStack;
 import logisticspipes.utils.item.ItemStackRenderer;
 import logisticspipes.utils.item.ItemStackRenderer.DisplayAmount;
 
@@ -297,7 +298,8 @@ public class HudChassisPipe extends BasicHUDGui {
                         false,
                         shifted,
                         renderInColor);
-                itemStackRenderer.setItemstack(module).setDisplayAmount(DisplayAmount.NEVER);
+                itemStackRenderer.setItemstack(ItemIdentifierStack.getFromStack(module))
+                        .setDisplayAmount(DisplayAmount.NEVER);
 
                 itemStackRenderer.renderInGui();
             }

--- a/src/main/java/logisticspipes/renderer/LogisticsHUDRenderer.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsHUDRenderer.java
@@ -407,7 +407,7 @@ public class LogisticsHUDRenderer {
                             GL11.glScalef(scaleX, scaleY, scaleZ);
 
                             ItemStackRenderer itemStackRenderer = new ItemStackRenderer(5, 6, 0.0F, false, true, true);
-                            itemStackRenderer.setItemstack(ItemIdentifierStack.getFromStack(item))
+                            itemStackRenderer.setItemIdentifierStack(ItemIdentifierStack.getFromStack(item))
                                     .setDisplayAmount(DisplayAmount.NEVER);
                             itemStackRenderer.setScaleX(scaleX).setScaleY(scaleY).setScaleZ(scaleZ);
 

--- a/src/main/java/logisticspipes/renderer/LogisticsHUDRenderer.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsHUDRenderer.java
@@ -35,6 +35,7 @@ import logisticspipes.routing.LaserData;
 import logisticspipes.routing.PipeRoutingConnectionType;
 import logisticspipes.utils.MathVector;
 import logisticspipes.utils.gui.GuiGraphics;
+import logisticspipes.utils.item.ItemIdentifierStack;
 import logisticspipes.utils.item.ItemStackRenderer;
 import logisticspipes.utils.item.ItemStackRenderer.DisplayAmount;
 import logisticspipes.utils.tuples.Pair;
@@ -406,7 +407,8 @@ public class LogisticsHUDRenderer {
                             GL11.glScalef(scaleX, scaleY, scaleZ);
 
                             ItemStackRenderer itemStackRenderer = new ItemStackRenderer(5, 6, 0.0F, false, true, true);
-                            itemStackRenderer.setItemstack(item).setDisplayAmount(DisplayAmount.NEVER);
+                            itemStackRenderer.setItemstack(ItemIdentifierStack.getFromStack(item))
+                                    .setDisplayAmount(DisplayAmount.NEVER);
                             itemStackRenderer.setScaleX(scaleX).setScaleY(scaleY).setScaleZ(scaleZ);
 
                             itemStackRenderer.renderInGui();

--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -201,9 +201,8 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                     || item.getContainer().zCoord != pipe.container.zCoord) {
                 continue;
             }
-            ItemStack itemstack = item.getItemIdentifierStack().makeNormalStack();
             doRenderItem(
-                    itemstack,
+                    item.getItemIdentifierStack(),
                     pipe.container.getWorldObj(),
                     x + pos.getXD(),
                     y + pos.getYD(),
@@ -224,9 +223,8 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
             if (item == null || item.getValue1() == null) {
                 continue;
             }
-            ItemStack itemstack = item.getValue1().makeNormalStack();
             doRenderItem(
-                    itemstack,
+                    item.getValue1(),
                     pipe.container.getWorldObj(),
                     x + pos.getXD(),
                     y + pos.getYD(),
@@ -253,10 +251,10 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
         GL11.glPopMatrix();
     }
 
-    public void doRenderItem(ItemStack itemstack, World worldObj, double x, double y, double z, float light,
+    public void doRenderItem(ItemIdentifierStack itemstack, World worldObj, double x, double y, double z, float light,
             float renderScale, double boxScale, float partialTickTime) {
         if (LogisticsRenderPipe.config.isUseNewRenderer() && boxScale != 0) {
-            LogisticsRenderPipe.boxRenderer.doRenderItem(itemstack, light, x, y, z, boxScale);
+            LogisticsRenderPipe.boxRenderer.doRenderItem(itemstack.makeNormalStack(), light, x, y, z, boxScale);
         }
 
         GL11.glPushMatrix();

--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -261,7 +261,7 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
         GL11.glTranslated(x, y, z);
         GL11.glScalef(renderScale, renderScale, renderScale);
         GL11.glTranslatef(0.0F, -0.1F, 0.0F);
-        itemRenderer.setItemstack(itemstack).setWorldObj(worldObj).setPartialTickTime(partialTickTime);
+        itemRenderer.setItemIdentifierStack(itemstack).setWorldObj(worldObj).setPartialTickTime(partialTickTime);
         itemRenderer.renderInWorld();
         GL11.glPopMatrix();
     }

--- a/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
+++ b/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
@@ -323,7 +323,7 @@ public class ItemDisplay {
 
                 // use GuiGraphics to render the ItemStacks
                 ItemStackRenderer itemstackRenderer = new ItemStackRenderer(x, y, 100.0F, true, false, true);
-                itemstackRenderer.setItemstack(itemIdentifierStack).setDisplayAmount(DisplayAmount.HIDE_ONE);
+                itemstackRenderer.setItemIdentifierStack(itemIdentifierStack).setDisplayAmount(DisplayAmount.HIDE_ONE);
                 itemstackRenderer.renderInGui();
 
                 x += panelxSize;

--- a/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
+++ b/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
@@ -323,7 +323,7 @@ public class ItemDisplay {
 
                 // use GuiGraphics to render the ItemStacks
                 ItemStackRenderer itemstackRenderer = new ItemStackRenderer(x, y, 100.0F, true, false, true);
-                itemstackRenderer.setItemstack(itemstack).setDisplayAmount(DisplayAmount.HIDE_ONE);
+                itemstackRenderer.setItemstack(itemIdentifierStack).setDisplayAmount(DisplayAmount.HIDE_ONE);
                 itemstackRenderer.renderInGui();
 
                 x += panelxSize;

--- a/src/main/java/logisticspipes/utils/item/ItemStackRenderer.java
+++ b/src/main/java/logisticspipes/utils/item/ItemStackRenderer.java
@@ -47,7 +47,7 @@ public class ItemStackRenderer {
     private TextureManager texManager;
     private FontRenderer fontRenderer;
 
-    private ItemIdentifierStack itemstack;
+    private ItemIdentifierStack itemIdentifierStack;
     private int posX;
     private int posY;
     private float zLevel;
@@ -140,8 +140,8 @@ public class ItemStackRenderer {
         int column = 0;
         int row = 0;
 
-        for (ItemIdentifierStack identifierStack : _allItems) {
-            if (identifierStack == null) {
+        for (ItemIdentifierStack itemIdentifierStack : _allItems) {
+            if (itemIdentifierStack == null) {
                 column++;
                 if (column >= columns) {
                     row++;
@@ -150,7 +150,7 @@ public class ItemStackRenderer {
                 ppi++;
                 continue;
             }
-            ItemIdentifier item = identifierStack.getItem();
+            ItemIdentifier item = itemIdentifierStack.getItem();
             if (IItemSearch != null && !IItemSearch.itemSearched(item)) {
                 continue;
             }
@@ -166,7 +166,7 @@ public class ItemStackRenderer {
             int x = left + xSize * column;
             int y = top + ySize * row + 1;
 
-            itemStackRenderer.setItemstack(identifierStack).setPosX(x).setPosY(y);
+            itemStackRenderer.setItemIdentifierStack(itemIdentifierStack).setPosX(x).setPosY(y);
             itemStackRenderer.renderInGui();
 
             column++;
@@ -178,7 +178,7 @@ public class ItemStackRenderer {
     }
 
     public void renderInGui() {
-        assert itemstack != null;
+        assert itemIdentifierStack != null;
         assert displayAmount != null;
         assert renderBlocks != null;
         assert renderItem != null;
@@ -206,7 +206,7 @@ public class ItemStackRenderer {
             GL11.glEnable(GL11.GL_DEPTH_TEST);
         }
 
-        ItemStack itemStack = itemstack.makeNormalStack();
+        ItemStack itemStack = itemIdentifierStack.makeNormalStack();
         if (!ForgeHooksClient
                 .renderInventoryItem(renderBlocks, texManager, itemStack, renderInColor, zLevel, posX, posY)) {
             renderItem.zLevel += zLevel;
@@ -233,7 +233,7 @@ public class ItemStackRenderer {
                 GL11.glEnable(GL11.GL_DEPTH_TEST);
             }
 
-            FontRenderer specialFontRenderer = itemstack.getItem().item.getFontRenderer(itemStack);
+            FontRenderer specialFontRenderer = itemIdentifierStack.getItem().item.getFontRenderer(itemStack);
 
             if (specialFontRenderer != null) {
                 fontRenderer = specialFontRenderer;
@@ -241,7 +241,7 @@ public class ItemStackRenderer {
 
             GL11.glDisable(GL11.GL_LIGHTING);
             String amountString = StringUtils
-                    .getFormatedStackSize(itemstack.getStackSize(), displayAmount == DisplayAmount.ALWAYS);
+                    .getFormatedStackSize(itemIdentifierStack.getStackSize(), displayAmount == DisplayAmount.ALWAYS);
 
             // 20 should be about the size of a block + 20 for the effect and overlay
             GL11.glTranslatef(0.0F, 0.0F, zLevel + 40.0F);
@@ -264,7 +264,7 @@ public class ItemStackRenderer {
         assert renderManager != null;
         assert renderItem != null;
 
-        ItemIdentifier itemId = itemstack.getItem();
+        ItemIdentifier itemId = itemIdentifierStack.getItem();
         EntityItem entityItem = entityCache.get(itemId);
         if (entityItem == null) {
             entityItem = new EntityItem(worldObj, 0, 0, 0, itemId.makeNormalStack(1));


### PR DESCRIPTION
... instead of ItemStack and cache EntityItem.

The current code has an `entiyItem` field on ItemStackRenderer. But for the use case of rendering items in pipes we only use a single ItemStackRenderer so the `entityItem` is actually never re-used and we create a fresh instance. This means in essence we create a new `EntityItem` instance every time an item travels down a pipe.

To optimize for the `renderInWorld` case of a single ItemStackRenderer, we cache one EntityItem for each item. To aid in this we refactor ItemStackRenderer to use an `ItemIdentifierStack` instead of an `ItemStack`. Most users of `ItemStackRenderer` use IdentifierStacks anyway.

The result is a small (but noticable) bump in FPS when lots of different items are traveling at the same time and less pressure on the GC for all the temporary `EntityItem`s.