### PR TITLE
refactor: Use format strings for debug logging

### DIFF
--- a/src/main/java/logisticspipes/logisticspipes/RouteLayer.java
+++ b/src/main/java/logisticspipes/logisticspipes/RouteLayer.java
@@ -33,7 +33,7 @@ public class RouteLayer {
         // If a item has no destination, find one
         if (item.getDestination() < 0) {
             item = SimpleServiceLocator.logisticsManager.assignDestinationFor(item, _router.getSimpleID(), false);
-            _pipe.debug.log("No Destination, assigned new destination: (" + item.getInfo());
+            _pipe.debug.log("No Destination, assigned new destination: (%s)", item.getInfo());
         }
 
         // If the destination is unknown / unroutable or it already arrived at its destination and somehow looped back
@@ -42,7 +42,7 @@ public class RouteLayer {
                 item.getTransportMode() == TransportMode.Active,
                 item.getItemIdentifierStack().getItem()) || item.getArrived())) {
             item = SimpleServiceLocator.logisticsManager.assignDestinationFor(item, _router.getSimpleID(), false);
-            _pipe.debug.log("Unreachable Destination, sssigned new destination: (" + item.getInfo());
+            _pipe.debug.log("Unreachable Destination, assigned new destination: (%s)", item.getInfo());
         }
 
         item.checkIDFromUUID();

--- a/src/main/java/logisticspipes/modules/ModuleActiveSupplier.java
+++ b/src/main/java/logisticspipes/modules/ModuleActiveSupplier.java
@@ -262,7 +262,7 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             int haveCount = 0;
             if (have != null) {
                 if (!have.getItem().equals(needed.getItem())) {
-                    _service.getDebug().log("Supplier: Slot for " + i + ", " + needed + " already taken by " + have);
+                    _service.getDebug().log("Supplier: Slot for %d, %s already taken by %s", i, needed, have);
                     setRequestFailed(true);
                     continue;
                 }
@@ -285,7 +285,7 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
 
             ItemIdentifierStack toRequest = new ItemIdentifierStack(needed.getItem(), neededCount);
 
-            _service.getDebug().log("Supplier: Missing for slot " + i + ": " + toRequest);
+            _service.getDebug().log("Supplier: Missing for slot %d: %s", i, toRequest);
 
             if (!_service.useEnergy(10)) {
                 break;
@@ -298,20 +298,16 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
                     needed.getStackSize());
 
             if (_patternMode != PatternMode.Full) {
-                _service.getDebug().log("Supplier: Requesting partial: " + toRequest);
+                _service.getDebug().log("Supplier: Requesting partial: %s", toRequest);
                 neededCount = RequestTree.requestPartial(toRequest, this, targetInformation);
-                _service.getDebug().log("Supplier: Requested: " + toRequest.getItem().makeStack(neededCount));
+                _service.getDebug().log("Supplier: Requested: %s", toRequest.getItem().makeStack(neededCount));
                 if (neededCount > 0) {
                     success = true;
                 }
             } else {
-                _service.getDebug().log("Supplier: Requesting: " + toRequest);
+                _service.getDebug().log("Supplier: Requesting: %s", toRequest);
                 success = RequestTree.request(toRequest, this, null, targetInformation);
-                if (success) {
-                    _service.getDebug().log("Supplier: Request success");
-                } else {
-                    _service.getDebug().log("Supplier: Request failed");
-                }
+                _service.getDebug().log("Supplier: Request %s", success ? "success" : "failed");
             }
 
             if (success) {
@@ -331,11 +327,11 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
         _service.getDebug().log("Supplier: Start calculating supply request");
         // How many do I want?
         HashMap<ItemIdentifier, Integer> needed = new HashMap<>(dummyInventory.getItemsAndCount());
-        _service.getDebug().log("Supplier: Needed: " + needed);
+        _service.getDebug().log("Supplier: Needed: %s", needed);
 
         // How many do I have?
         Map<ItemIdentifier, Integer> have = invUtil.getItemsAndCount();
-        _service.getDebug().log("Supplier: Have:   " + have);
+        _service.getDebug().log("Supplier: Have:   %s", have);
 
         // How many do I have?
         HashMap<ItemIdentifier, Integer> haveUndamaged = new HashMap<>();
@@ -374,7 +370,7 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             }
         }
 
-        _service.getDebug().log("Supplier: Missing:   " + needed);
+        _service.getDebug().log("Supplier: Missing:   %s", needed);
 
         setRequestFailed(false);
 
@@ -403,25 +399,20 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             } else {
                 _service.getDebug().log("Supplier: Requesting: " + need.getKey().makeStack(neededCount));
                 success = RequestTree.request(need.getKey().makeStack(neededCount), this, null, targetInformation);
-                if (success) {
-                    _service.getDebug().log("Supplier: Request success");
-                } else {
-                    _service.getDebug().log("Supplier: Request failed");
-                }
+                _service.getDebug().log("Supplier: Request %s", success ? "success" : "failed");
             }
 
             if (success) {
                 Integer currentRequest = _requestedItems.get(need.getKey());
                 if (currentRequest == null) {
                     _requestedItems.put(need.getKey(), neededCount);
-                    _service.getDebug().log("Supplier: Inserting Requested Items: " + neededCount);
+                    _service.getDebug().log("Supplier: Inserting Requested Items: %d", neededCount);
                 } else {
                     _requestedItems.put(need.getKey(), currentRequest + neededCount);
                     _service.getDebug().log(
-                            "Supplier: Raising Requested Items from: " + currentRequest
-                                    + " to: "
-                                    + currentRequest
-                                    + neededCount);
+                            "Supplier: Raising Requested Items from: %d to: %d",
+                            currentRequest,
+                            currentRequest + neededCount);
                 }
             } else {
                 setRequestFailed(true);
@@ -470,7 +461,7 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
         // see if we can get an exact match
         Integer count = _requestedItems.get(item.getItem());
         if (count != null) {
-            _service.getDebug().log("Supplier: Exact match. Still missing: " + Math.max(0, count - remaining));
+            _service.getDebug().log("Supplier: Exact match. Still missing: %d", Math.max(0, count - remaining));
             if (count - remaining > 0) {
                 _requestedItems.put(item.getItem(), count - remaining);
             } else {
@@ -487,8 +478,8 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             Entry<ItemIdentifier, Integer> e = it.next();
             if (e.getKey().equalsWithoutNBT(item.getItem())) {
                 int expected = e.getValue();
-                _service.getDebug().log(
-                        "Supplier: Fuzzy match with" + e + ". Still missing: " + Math.max(0, expected - remaining));
+                _service.getDebug()
+                        .log("Supplier: Fuzzy match with %s. Still missing: %d", e, Math.max(0, expected - remaining));
                 if (expected - remaining > 0) {
                     e.setValue(expected - remaining);
                 } else {
@@ -501,18 +492,18 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             }
         }
         // we have no idea what this is, log it.
-        _service.getDebug().log("Supplier: supplier got unexpected item " + item);
+        _service.getDebug().log("Supplier: supplier got unexpected item %s", item);
     }
 
     @Override
     public void itemLost(ItemIdentifierStack item, IAdditionalTargetInformation info) {
-        _service.getDebug().log("Supplier: Registered Item Lost: " + item);
+        _service.getDebug().log("Supplier: Registered Item Lost: %s", item);
         decreaseRequested(item);
     }
 
     @Override
     public void itemArrived(ItemIdentifierStack item, IAdditionalTargetInformation info) {
-        _service.getDebug().log("Supplier: Registered Item Arrived: " + item);
+        _service.getDebug().log("Supplier: Registered Item Arrived: %s", item);
         decreaseRequested(item);
     }
 

--- a/src/main/java/logisticspipes/pipes/PipeFluidSupplierMk2.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidSupplierMk2.java
@@ -273,7 +273,7 @@ public class PipeFluidSupplierMk2 extends FluidRoutedPipe implements IRequestFlu
         else _requestedItems.put(liquid, count - remaining);
         if (remaining > count) {
             // we have no idea what this is, log it.
-            debug.log("liquid supplier got unexpected item " + liquid.toString());
+            debug.log("liquid supplier got unexpected item %s", liquid.toString());
         }
     }
 

--- a/src/main/java/logisticspipes/pipes/PipeItemsFluidSupplier.java
+++ b/src/main/java/logisticspipes/pipes/PipeItemsFluidSupplier.java
@@ -290,7 +290,7 @@ public class PipeItemsFluidSupplier extends CoreRoutedPipe implements IRequestIt
             }
         }
         // we have no idea what this is, log it.
-        debug.log("liquid supplier got unexpected item " + item);
+        debug.log("liquid supplier got unexpected item %s", item);
     }
 
     @Override

--- a/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
@@ -399,9 +399,9 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe
             final ItemRoutingInformation p = _inTransitToMe.poll();
             if (p != null) {
                 if (LPConstants.DEBUG) {
-                    LogisticsPipes.log.info("Timed Out: " + p.getItem().getFriendlyName() + " (" + p.hashCode() + ")");
+                    LogisticsPipes.log.info("Timed Out: {} ({})", p.getItem().getFriendlyName(), p.hashCode());
                 }
-                debug.log("Timed Out: " + p.getItem().getFriendlyName() + " (" + p.hashCode() + ")");
+                debug.log("Timed Out: %s (%d)", p.getItem().getFriendlyName(), p.hashCode());
             }
         }
         // update router before ticking logic/transport

--- a/src/main/java/logisticspipes/pipes/basic/debug/DebugLogController.java
+++ b/src/main/java/logisticspipes/pipes/basic/debug/DebugLogController.java
@@ -26,12 +26,14 @@ public class DebugLogController {
         this.pipe = pipe;
     }
 
-    public void log(String info) {
+    public void log(String formatString, Object... args) {
         if (players.isEmptyWithoutCheck()) {
             return;
         }
-        MainProxy
-                .sendToPlayerList(PacketHandler.getPacket(SendNewLogLine.class).setWindowID(ID).setLine(info), players);
+        MainProxy.sendToPlayerList(
+                PacketHandler.getPacket(SendNewLogLine.class).setWindowID(ID)
+                        .setLine(String.format(formatString, args)),
+                players);
     }
 
     public void tick() {

--- a/src/main/java/logisticspipes/transport/PipeTransportLogistics.java
+++ b/src/main/java/logisticspipes/transport/PipeTransportLogistics.java
@@ -206,11 +206,10 @@ public class PipeTransportLogistics {
                 return 0;
             }
             getPipe().debug.log(
-                    "Injected Item: [" + item.input
-                            + ", "
-                            + item.output
-                            + "] ("
-                            + ((LPTravelingItemServer) item).getInfo());
+                    "Injected Item: [%s, %s] (%s)",
+                    item.input,
+                    item.output,
+                    ((LPTravelingItemServer) item).getInfo());
         } else {
             item.output = ForgeDirection.UNKNOWN;
         }


### PR DESCRIPTION
The current approach requires a ton of StringBuilder instances under the hood for all the string concatenations even if debug logging is disabled. The `.log` call in `PipeTransportLogistics` is particularily excessive and showed up in the allocation flamegraph.

This PR converts `.log` to a standard format string plus arguments approach so we only format the full debug lines when they are really needed.