### PR TITLE
refactor: Simplify LPBCPluggableState.isDiry check

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,6 @@
+test {
+    useJUnitPlatform()
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,4 +29,7 @@ dependencies {
 	compileOnly('curse.maven:minefactory-reloaded-66672:2366150') { transitive = false }
 
 	annotationProcessor('org.projectlombok:lombok:1.18.24')
+
+    testImplementation(platform('org.junit:junit-bom:5.10.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
 }

--- a/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
@@ -231,7 +231,7 @@ public class LogisticsTileGenericPipe extends TileEntity
             refreshRenderState = false;
         }
 
-        if (bcPlugableState.isDirty(true)) {
+        if (bcPlugableState.isDirty()) {
             sendUpdateToClient();
         }
 

--- a/src/main/java/logisticspipes/proxy/ProxyManager.java
+++ b/src/main/java/logisticspipes/proxy/ProxyManager.java
@@ -304,7 +304,7 @@ public class ProxyManager {
                                     public void readData(LPDataInputStream data) {}
 
                                     @Override
-                                    public boolean isDirty(boolean clean) {
+                                    public boolean isDirty() {
                                         return false;
                                     }
                                 };

--- a/src/main/java/logisticspipes/proxy/buildcraft/subproxies/IBCPluggableState.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/subproxies/IBCPluggableState.java
@@ -14,5 +14,5 @@ public interface IBCPluggableState extends IClientState {
     @Override
     void readData(LPDataInputStream data) throws IOException;
 
-    boolean isDirty(boolean clean);
+    boolean isDirty();
 }

--- a/src/test/java/logisticspipes/proxy/buildcraft/subproxies/LPBCPluggableStateTest.java
+++ b/src/test/java/logisticspipes/proxy/buildcraft/subproxies/LPBCPluggableStateTest.java
@@ -1,0 +1,86 @@
+package logisticspipes.proxy.buildcraft.subproxies;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.junit.jupiter.api.Test;
+
+import buildcraft.api.transport.IPipeTile;
+import buildcraft.api.transport.pluggable.IPipePluggableRenderer;
+import buildcraft.api.transport.pluggable.PipePluggable;
+import io.netty.buffer.ByteBuf;
+
+class LPBCPluggableStateTest {
+
+    private static class FakePipePluggable extends PipePluggable {
+
+        /** The data we'll write to the buffer so we can have different pluggables */
+        private final long data;
+
+        FakePipePluggable(long data) {
+            this.data = data;
+        }
+
+        @Override
+        public ItemStack[] getDropItems(IPipeTile pipe) {
+            return new ItemStack[0];
+        }
+
+        @Override
+        public boolean isBlocking(IPipeTile pipe, ForgeDirection direction) {
+            return false;
+        }
+
+        @Override
+        public AxisAlignedBB getBoundingBox(ForgeDirection side) {
+            return null;
+        }
+
+        @Override
+        public IPipePluggableRenderer getRenderer() {
+            return null;
+        }
+
+        @Override
+        public void readFromNBT(NBTTagCompound tag) {}
+
+        @Override
+        public void writeToNBT(NBTTagCompound tag) {}
+
+        @Override
+        public void writeData(ByteBuf data) {
+            data.writeLong(this.data);
+        }
+
+        @Override
+        public void readData(ByteBuf data) {}
+    }
+
+    @Test
+    void isDirty() {
+        LPBCPluggableState state = new LPBCPluggableState();
+        assertTrue(state.isDirty());
+        assertFalse(state.isDirty());
+
+        PipePluggable[] pluggables = new PipePluggable[6];
+        state.setPluggables(pluggables);
+        assertFalse(state.isDirty());
+
+        pluggables[0] = new FakePipePluggable(1);
+        pluggables[1] = new FakePipePluggable(2);
+        assertTrue(state.isDirty());
+        assertFalse(state.isDirty());
+
+        pluggables[4] = new FakePipePluggable(4);
+        assertTrue(state.isDirty());
+        assertFalse(state.isDirty());
+
+        // Assign an ew pluggable but with the same data.
+        pluggables[4] = new FakePipePluggable(4);
+        assertFalse(state.isDirty());
+    }
+}


### PR DESCRIPTION
We can use ByteBuf.equals directly. No need to go back to raw byte arrays. We can also skip the temporary
LPDataOutputStream. All it does is prepend the data's length. Which in the end does not factor into the equals check anyway.

Instead of re-allocating a new buffer and byte array copies, we can use 2 ByteBufs. One for the old state and one as a working buffer. After the check we just swap them to save us the hazzle of copying the data or allocating a fresh working ByteBuf.

Drive-by: Added JUnit as a dependency and configured it so `gradlew :test` runs the unit tests.