### PR TITLE
cleanup: Skip unused string concatenation

### DIFF
--- a/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
@@ -165,8 +165,11 @@ public class LogisticsTileGenericPipe extends TileEntity
 
     @Override
     public void updateEntity() {
-        Info superDebug = StackTraceUtil.addSuperTraceInformation("Time: " + getWorld().getWorldTime());
-        Info debug = StackTraceUtil.addTraceInformation("(" + getX() + ", " + getY() + ", " + getZ() + ")", superDebug);
+        Info debug = StackTraceUtil.DUMMY_INFO;
+        if (LPConstants.DEBUG) {
+            Info superDebug = StackTraceUtil.addSuperTraceInformation("Time: " + getWorld().getWorldTime());
+            debug = StackTraceUtil.addTraceInformation("(" + getX() + ", " + getY() + ", " + getZ() + ")", superDebug);
+        }
         if (sendInitPacket && MainProxy.isServer(getWorldObj())) {
             sendInitPacket = false;
             getRenderController().sendInit();

--- a/src/main/java/logisticspipes/utils/StackTraceUtil.java
+++ b/src/main/java/logisticspipes/utils/StackTraceUtil.java
@@ -18,7 +18,7 @@ public class StackTraceUtil {
         public abstract void end();
     }
 
-    private static final Info dummyInfo = new Info() {
+    public static final Info DUMMY_INFO = new Info() {
 
         @Override
         public void end() {}
@@ -30,7 +30,7 @@ public class StackTraceUtil {
 
     public static Info addTraceInformation(final String information, Info... infos) {
         if (!LPConstants.DEBUG) {
-            return dummyInfo;
+            return DUMMY_INFO;
         }
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
         final StackTraceElement calledFrom = trace[2];
@@ -39,7 +39,7 @@ public class StackTraceUtil {
 
     public static Info addSuperTraceInformation(final String information, Info... infos) {
         if (!LPConstants.DEBUG) {
-            return dummyInfo;
+            return DUMMY_INFO;
         }
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
         final StackTraceElement calledFrom = trace[3];


### PR DESCRIPTION
`updateEntity` in `LogisticsTileGenericPipe` currently creates debug strings that go unused in normal release builds. We can skip allocating temporary `StringBuilder` instances by checking the DEBUG flag directly.

Normally we'd use a format string with an additional varargs argument, but the `add(Super)TraceInformation` methods already use a varargs parameter to pass nested `Infos`. This is the pragmatic, cheap way to remove the calls from the hot path.