### PR TITLE
cleanup: LogisticsNewPipeItemBoxRenderer takes an ItemIdentifierStack

### DIFF
--- a/src/main/java/logisticspipes/proxy/buildcraft/BCLPPipeTransportItemsRenderer.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCLPPipeTransportItemsRenderer.java
@@ -4,6 +4,7 @@ import buildcraft.api.core.EnumColor;
 import buildcraft.transport.TravelingItem;
 import buildcraft.transport.render.PipeTransportItemsRenderer;
 import logisticspipes.renderer.LogisticsRenderPipe;
+import logisticspipes.utils.item.ItemIdentifierStack;
 
 public class BCLPPipeTransportItemsRenderer extends PipeTransportItemsRenderer {
 
@@ -14,8 +15,9 @@ public class BCLPPipeTransportItemsRenderer extends PipeTransportItemsRenderer {
             if (travellingItem.getItemStack().getTagCompound().getString("LogsitcsPipes_ITEM_ON_TRANSPORTATION")
                     .equals("YES")) {
                 if (LogisticsRenderPipe.boxRenderer != null) {
-                    LogisticsRenderPipe.boxRenderer
-                            .doRenderItem(travellingItem.getItemStack(), light, x, y + 0.25, z, 1.0D);
+                    ItemIdentifierStack itemIdentifierStack = ItemIdentifierStack
+                            .getFromStack(travellingItem.getItemStack());
+                    LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, light, x, y + 0.25, z, 1.0D);
                 }
             }
         }

--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -251,17 +251,18 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
         GL11.glPopMatrix();
     }
 
-    public void doRenderItem(ItemIdentifierStack itemstack, World worldObj, double x, double y, double z, float light,
-            float renderScale, double boxScale, float partialTickTime) {
+    public void doRenderItem(ItemIdentifierStack itemIdentifierStack, World worldObj, double x, double y, double z,
+            float light, float renderScale, double boxScale, float partialTickTime) {
         if (LogisticsRenderPipe.config.isUseNewRenderer() && boxScale != 0) {
-            LogisticsRenderPipe.boxRenderer.doRenderItem(itemstack.makeNormalStack(), light, x, y, z, boxScale);
+            LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, light, x, y, z, boxScale);
         }
 
         GL11.glPushMatrix();
         GL11.glTranslated(x, y, z);
         GL11.glScalef(renderScale, renderScale, renderScale);
         GL11.glTranslatef(0.0F, -0.1F, 0.0F);
-        itemRenderer.setItemIdentifierStack(itemstack).setWorldObj(worldObj).setPartialTickTime(partialTickTime);
+        itemRenderer.setItemIdentifierStack(itemIdentifierStack).setWorldObj(worldObj)
+                .setPartialTickTime(partialTickTime);
         itemRenderer.renderInWorld();
         GL11.glPopMatrix();
     }

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -28,7 +27,8 @@ public class LogisticsNewPipeItemBoxRenderer {
     private static final ResourceLocation BLOCKS = new ResourceLocation("textures/atlas/blocks.png");
     private static final Map<FluidIdentifier, int[]> renderLists = new HashMap<>();
 
-    public void doRenderItem(ItemStack itemstack, float light, double x, double y, double z, double boxScale) {
+    public void doRenderItem(ItemIdentifierStack itemIdentifierStack, float light, double x, double y, double z,
+            double boxScale) {
         if (LogisticsNewRenderPipe.innerTransportBox == null) return;
         GL11.glPushMatrix();
 
@@ -51,9 +51,8 @@ public class LogisticsNewPipeItemBoxRenderer {
         GL11.glScaled(1 / boxScale, 1 / boxScale, 1 / boxScale);
         GL11.glTranslated(-0.5, -0.5, -0.5);
 
-        if (itemstack != null && itemstack.getItem() instanceof LogisticsFluidContainer) {
-            FluidStack f = SimpleServiceLocator.logisticsFluidManager
-                    .getFluidFromContainer(ItemIdentifierStack.getFromStack(itemstack));
+        if (itemIdentifierStack != null && itemIdentifierStack.getItem().item instanceof LogisticsFluidContainer) {
+            FluidStack f = SimpleServiceLocator.logisticsFluidManager.getFluidFromContainer(itemIdentifierStack);
             if (f != null) {
                 FluidContainerRenderer.skipNext = true;
                 int list = getRenderListFor(f);


### PR DESCRIPTION
For doRenderItem there is no need to convert first to an ItemStack and then back to an ItemIdentifierStack on the hotpath if we can just pass the ItemIdentifierStack directly.

This is a follow up to GTNewHorizons/LogisticsPipes#40.