### PR TITLE
fix: Drastically reduce number of display lists when transporting fluids

### DIFF
--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
@@ -72,12 +72,8 @@ public class LogisticsNewPipeItemBoxRenderer {
     }
 
     private int getRenderListFor(FluidStack fluid) {
-        FluidIdentifier ident = FluidIdentifier.get(fluid);
-        int[] array = LogisticsNewPipeItemBoxRenderer.renderLists.get(fluid);
-        if (array == null) {
-            array = new int[LogisticsNewPipeItemBoxRenderer.RENDER_SIZE];
-            LogisticsNewPipeItemBoxRenderer.renderLists.put(ident, array);
-        }
+        int[] array = LogisticsNewPipeItemBoxRenderer.renderLists
+                .computeIfAbsent(FluidIdentifier.get(fluid), k -> new int[LogisticsNewPipeItemBoxRenderer.RENDER_SIZE]);
         int pos = Math.min(
                 (int) (((Math.min(fluid.amount, 5000) * 1.0F) * LogisticsNewPipeItemBoxRenderer.RENDER_SIZE) / 5000),
                 LogisticsNewPipeItemBoxRenderer.RENDER_SIZE - 1);


### PR DESCRIPTION
LogisticsNewPipeItemBoxRenderer has a display list cache for rendering fluids. Unfortunately there is a small bug/typo where a `FluidStack` is used as the key for lookup, but a `FluidIdentifier` is used for writing the cached display list array.

Essentially, the cache is unused and we create a fresh display list for every traveling liquid box in every frame.

To fix, we simply use the FluidIdentifier consistently. This should help with FPS in networks with lots of (vsibily) traveling fluids.