### PR TITLE
cleanup: Skip unnecessary NBT copying when checking for Item class

### DIFF
--- a/src/main/java/logisticspipes/logistics/LogisticsFluidManager.java
+++ b/src/main/java/logisticspipes/logistics/LogisticsFluidManager.java
@@ -65,7 +65,7 @@ public class LogisticsFluidManager implements ILogisticsFluidManager {
 
     @Override
     public FluidStack getFluidFromContainer(ItemIdentifierStack stack) {
-        if (stack.makeNormalStack().getItem() instanceof LogisticsFluidContainer && stack.getItem().tag != null) {
+        if (stack.getItem().item instanceof LogisticsFluidContainer && stack.getItem().tag != null) {
             return FluidStack.loadFluidStackFromNBT(stack.getItem().tag);
         }
         return null;


### PR DESCRIPTION
We can take the underlying `Item` from an `ItemIdentifierStack` directly without converting to an `ItemStack` first. The temporary `ItemStack` is heavy-weight for fluids since the fluid/amount is stored in an NBT that has to be copied.