### PR TITLE
refactor: Use MethodHandle to prevent autoboxing allocations

### DIFF
--- a/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
@@ -1,5 +1,7 @@
 package logisticspipes.proxy.buildcraft;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 
 import buildcraft.transport.TileGenericPipe;
@@ -10,32 +12,37 @@ import lombok.SneakyThrows;
 
 public class BCRenderTESR implements IBCRenderTESR {
 
-    private final Method renderGatesWires;
-    private final Method renderPluggables;
+    private final MethodHandle renderGatesWires;
+    private final MethodHandle renderPluggables;
 
     @SneakyThrows(Exception.class)
     BCRenderTESR() {
-        renderGatesWires = PipeRendererTESR.class.getDeclaredMethod(
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+        Method renderGatesWiresMethod = PipeRendererTESR.class.getDeclaredMethod(
                 "renderGatesWires",
                 new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
-        renderGatesWires.setAccessible(true);
-        renderPluggables = PipeRendererTESR.class.getDeclaredMethod(
+        renderGatesWiresMethod.setAccessible(true);
+        renderGatesWires = lookup.unreflect(renderGatesWiresMethod);
+
+        Method renderPluggablesMethod = PipeRendererTESR.class.getDeclaredMethod(
                 "renderPluggables",
                 new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
-        renderPluggables.setAccessible(true);
+        renderPluggablesMethod.setAccessible(true);
+        renderPluggables = lookup.unreflect(renderPluggablesMethod);
     }
 
     @Override
-    @SneakyThrows(Exception.class)
+    @SneakyThrows(Throwable.class)
     public void renderWires(LogisticsTileGenericPipe pipe, double x, double y, double z) {
         TileGenericPipe tgPipe = (TileGenericPipe) pipe.tilePart.getOriginal();
-        renderGatesWires.invoke(PipeRendererTESR.INSTANCE, tgPipe, x, y, z);
+        renderGatesWires.invokeExact(PipeRendererTESR.INSTANCE, tgPipe, x, y, z);
     }
 
     @Override
-    @SneakyThrows(Exception.class)
+    @SneakyThrows(Throwable.class)
     public void dynamicRenderPluggables(LogisticsTileGenericPipe pipe, double x, double y, double z) {
         TileGenericPipe tgPipe = (TileGenericPipe) pipe.tilePart.getOriginal();
-        renderPluggables.invoke(PipeRendererTESR.INSTANCE, tgPipe, x, y, z);
+        renderPluggables.invokeExact(PipeRendererTESR.INSTANCE, tgPipe, x, y, z);
     }
 }

--- a/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
@@ -21,16 +21,12 @@ public class BCRenderTESR implements IBCRenderTESR {
         renderPluggables = getHandle(lookup, "renderPluggables");
     }
 
+    @SneakyThrows
     private static MethodHandle getHandle(MethodHandles.Lookup lookup, String methodName) {
-        try {
-            Method method = PipeRendererTESR.class.getDeclaredMethod(
-                    methodName,
-                    new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
-            method.setAccessible(true);
-            return lookup.unreflect(method);
-        } catch (Exception ignored) {
-            return null;
-        }
+        Method method = PipeRendererTESR.class
+                .getDeclaredMethod(methodName, TileGenericPipe.class, double.class, double.class, double.class);
+        method.setAccessible(true);
+        return lookup.unreflect(method);
     }
 
     @Override

--- a/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCRenderTESR.java
@@ -12,24 +12,25 @@ import lombok.SneakyThrows;
 
 public class BCRenderTESR implements IBCRenderTESR {
 
-    private final MethodHandle renderGatesWires;
-    private final MethodHandle renderPluggables;
+    private static final MethodHandle renderGatesWires;
+    private static final MethodHandle renderPluggables;
 
-    @SneakyThrows(Exception.class)
-    BCRenderTESR() {
+    static {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
+        renderGatesWires = getHandle(lookup, "renderGatesWires");
+        renderPluggables = getHandle(lookup, "renderPluggables");
+    }
 
-        Method renderGatesWiresMethod = PipeRendererTESR.class.getDeclaredMethod(
-                "renderGatesWires",
-                new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
-        renderGatesWiresMethod.setAccessible(true);
-        renderGatesWires = lookup.unreflect(renderGatesWiresMethod);
-
-        Method renderPluggablesMethod = PipeRendererTESR.class.getDeclaredMethod(
-                "renderPluggables",
-                new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
-        renderPluggablesMethod.setAccessible(true);
-        renderPluggables = lookup.unreflect(renderPluggablesMethod);
+    private static MethodHandle getHandle(MethodHandles.Lookup lookup, String methodName) {
+        try {
+            Method method = PipeRendererTESR.class.getDeclaredMethod(
+                    methodName,
+                    new Class[] { TileGenericPipe.class, double.class, double.class, double.class });
+            method.setAccessible(true);
+            return lookup.unreflect(method);
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
With MethodHandle.invokeExact we can skip the autoboxing allocations from the BCRenderTESR when a player is looking at logistic pipes. These allocations accounted for 5MB+ over a minute in a test world.