### PR TITLE
fix: Skip unnecessary ByteBuf copy when serializing packets

### DIFF
--- a/src/main/java/logisticspipes/network/PacketHandler.java
+++ b/src/main/java/logisticspipes/network/PacketHandler.java
@@ -120,7 +120,7 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, ModernP
         buffer.writeShort(msg.getId());
         buffer.writeInt(msg.getDebugId());
         msg.writeData(new LPDataOutputStream(buffer));
-        return new FMLProxyPacket(buffer.copy(), channel);
+        return new FMLProxyPacket(buffer, channel);
     }
 
     @Override


### PR DESCRIPTION
The LPDataOutputStream is only temporary and doesn't retain the buffer for further use, so there is no need to create an extra byte-by-byte copy for FMLProxyPacket.

To be honest, I'm not 100% sure about this change. I tested it both in SP and MP and everything looks fine, but it would be good for someone with more modding experience to confirm that this copy is indeed not required.