### PR TITLE
feat: Add player config option for a new VBO renderer

### DIFF
--- a/src/main/java/logisticspipes/config/PlayerConfig.java
+++ b/src/main/java/logisticspipes/config/PlayerConfig.java
@@ -37,6 +37,8 @@ public class PlayerConfig {
 
     private boolean useNewRenderer = true;
 
+    private boolean useVBORenderer = false;
+
     @Getter
     private boolean useFallbackRenderer = true;
 
@@ -62,6 +64,10 @@ public class PlayerConfig {
         useNewRenderer = flag;
     }
 
+    public void setUseVBORenderer(boolean flag) {
+        useVBORenderer = flag;
+    }
+
     public void setUseFallbackRenderer(boolean flag) {
         useFallbackRenderer = flag;
     }
@@ -80,6 +86,7 @@ public class PlayerConfig {
 
     public void writeData(LPDataOutputStream data) throws IOException {
         data.writeBoolean(useNewRenderer);
+        data.writeBoolean(useVBORenderer);
         data.writeBoolean(useFallbackRenderer);
         data.writeInt(renderPipeDistance);
         data.writeInt(renderPipeContentDistance);
@@ -87,6 +94,7 @@ public class PlayerConfig {
 
     public void readData(LPDataInputStream data) throws IOException {
         useNewRenderer = data.readBoolean();
+        useVBORenderer = data.readBoolean();
         useFallbackRenderer = data.readBoolean();
         renderPipeDistance = data.readInt();
         renderPipeContentDistance = data.readInt();
@@ -150,6 +158,7 @@ public class PlayerConfig {
             return;
         }
         useNewRenderer = lpUserData.getBoolean("useNewRenderer");
+        useVBORenderer = lpUserData.getBoolean("useVBORenderer");
         renderPipeDistance = lpUserData.getInteger("renderPipeDistance");
         renderPipeContentDistance = lpUserData.getInteger("renderPipeContentDistance");
         useFallbackRenderer = lpUserData.getBoolean("useFallbackRenderer");
@@ -169,6 +178,7 @@ public class PlayerConfig {
         File lpNameLookup = new File(lpData, "names");
         NBTTagCompound lpUserData = new NBTTagCompound();
         lpUserData.setBoolean("useNewRenderer", useNewRenderer);
+        lpUserData.setBoolean("useVBORenderer", useVBORenderer);
         lpUserData.setBoolean("useFallbackRenderer", useFallbackRenderer);
         lpUserData.setInteger("renderPipeDistance", renderPipeDistance);
         lpUserData.setInteger("renderPipeContentDistance", renderPipeContentDistance);
@@ -216,11 +226,16 @@ public class PlayerConfig {
         playerConfig.renderPipeContentDistance = renderPipeContentDistance;
         playerConfig.renderPipeDistance = renderPipeDistance;
         playerConfig.useNewRenderer = useNewRenderer;
+        playerConfig.useVBORenderer = useVBORenderer;
         playerConfig.useFallbackRenderer = useFallbackRenderer;
         playerConfig.isUninitialised = false;
     }
 
     public boolean isUseNewRenderer() {
         return useNewRenderer && SimpleServiceLocator.cclProxy.isActivated();
+    }
+
+    public boolean isUseVBORenderer() {
+        return useVBORenderer && SimpleServiceLocator.cclProxy.isActivated();
     }
 }

--- a/src/main/java/logisticspipes/gui/GuiLogisticsSettings.java
+++ b/src/main/java/logisticspipes/gui/GuiLogisticsSettings.java
@@ -23,7 +23,7 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
     private final String PREFIX = "gui.settings.";
 
     public GuiLogisticsSettings(final EntityPlayer player) {
-        super(180, 220);
+        super(220, 220);
         DummyContainer dummy = new DummyContainer(player, null);
         dummy.addNormalSlotsForPlayerInventory(10, 135);
 
@@ -36,6 +36,7 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
 
         private SearchBar renderDistance;
         private SearchBar contentRenderDistance;
+        private GuiCheckBox useVBORendererButton;
         private GuiCheckBox useNewRendererButton;
         private GuiCheckBox useFallbackRendererButton;
 
@@ -45,10 +46,10 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
         public void initTab() {
             PlayerConfig config = LogisticsPipes.getClientPlayerConfig();
             if (renderDistance == null) {
-                renderDistance = new SearchBar(fontRendererObj, getBaseScreen(), 15, 75, 30, 15, false, true, true);
+                renderDistance = new SearchBar(fontRendererObj, getBaseScreen(), 15, 95, 30, 15, false, true, true);
                 renderDistance.searchinput1 = config.getRenderPipeDistance() + "";
             }
-            renderDistance.reposition(15, 80, 30, 15);
+            renderDistance.reposition(15, 94, 30, 15);
             if (contentRenderDistance == null) {
                 contentRenderDistance = new SearchBar(
                         fontRendererObj,
@@ -62,11 +63,13 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
                         true);
                 contentRenderDistance.searchinput1 = config.getRenderPipeContentDistance() + "";
             }
-            contentRenderDistance.reposition(15, 110, 30, 15);
+            contentRenderDistance.reposition(15, 114, 30, 15);
             useNewRendererButton = (GuiCheckBox) addButton(
                     new GuiCheckBox(0, guiLeft + 15, guiTop + 30, 16, 16, config.isUseNewRenderer()));
+            useVBORendererButton = (GuiCheckBox) addButton(
+                    new GuiCheckBox(0, guiLeft + 15, guiTop + 50, 16, 16, config.isUseVBORenderer()));
             useFallbackRendererButton = (GuiCheckBox) addButton(
-                    new GuiCheckBox(0, guiLeft + 15, guiTop + 50, 16, 16, config.isUseFallbackRenderer()));
+                    new GuiCheckBox(0, guiLeft + 15, guiTop + 70, 16, 16, config.isUseFallbackRenderer()));
         }
 
         @Override
@@ -91,6 +94,9 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
             if (button == useNewRendererButton) {
                 useNewRendererButton.change();
             }
+            if (button == useVBORendererButton) {
+                useVBORendererButton.change();
+            }
             if (button == useFallbackRendererButton) {
                 useFallbackRendererButton.change();
             }
@@ -101,9 +107,10 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
             renderDistance.renderSearchBar();
             contentRenderDistance.renderSearchBar();
             fontRendererObj.drawString(StringUtils.translate(PREFIX + "pipenewrenderer"), 38, 34, 0x404040);
-            fontRendererObj.drawString(StringUtils.translate(PREFIX + "pipefallbackrenderer"), 38, 54, 0x404040);
-            fontRendererObj.drawString(StringUtils.translate(PREFIX + "piperenderdistance"), 10, 70, 0x404040);
-            fontRendererObj.drawString(StringUtils.translate(PREFIX + "pipecontentrenderdistance"), 10, 100, 0x404040);
+            fontRendererObj.drawString(StringUtils.translate(PREFIX + "pipevborenderer"), 38, 54, 0x404040);
+            fontRendererObj.drawString(StringUtils.translate(PREFIX + "pipefallbackrenderer"), 38, 74, 0x404040);
+            fontRendererObj.drawString(StringUtils.translate(PREFIX + "piperenderdistance"), 53, 98, 0x404040);
+            fontRendererObj.drawString(StringUtils.translate(PREFIX + "pipecontentrenderdistance"), 53, 118, 0x404040);
         }
 
         @Override
@@ -128,6 +135,7 @@ public class GuiLogisticsSettings extends LogisticsBaseTabGuiScreen {
                 e.printStackTrace();
             }
             config.setUseNewRenderer(useNewRendererButton.getState());
+            config.setUseVBORenderer(useVBORendererButton.getState());
             config.setUseFallbackRenderer(useFallbackRendererButton.getState());
             config.sendUpdate();
         }

--- a/src/main/resources/assets/logisticspipes/lang/en_US.lang
+++ b/src/main/resources/assets/logisticspipes/lang/en_US.lang
@@ -455,6 +455,7 @@ gui.networkstatistics.gettasks=Acquire tasks
 gui.networkstatistics.add.alreadytracked=This item type is already tracked
 
 gui.settings.pipenewrenderer=Use New Renderer
+gui.settings.pipevborenderer=Use VBO Renderer (experimental)
 gui.settings.pipefallbackrenderer=Use Fallback Renderer
 gui.settings.piperenderdistance=Max. Distance for new Renderer
 gui.settings.pipecontentrenderdistance=Max. Distance for Pipe Content


### PR DESCRIPTION
Enabling the option is not doing anything just yet, but it allows us to experiment and develop the new renderer without disrupting anything. Normally I would have added this as standard config option, but since LP already has a mechanism to switch between "new" and BuildCraft style rendering, I added it to the GUI as well. This also makes easier to develop/debug, since you can repeatedly switch between old/new without restarting MC.

Once the new renderer works (or the experiment fails), we'll fold the VBO renderer into "new" renderer, since the actual visuals will stay the same. Only the underlying implementation will change.

Before:
![Screenshot 2024-05-25 121346](https://github.com/GTNewHorizons/LogisticsPipes/assets/325588/7a489bd7-f1e6-405f-8517-bfb10a1488f6)

After:
![Screenshot 2024-05-25 122001](https://github.com/GTNewHorizons/LogisticsPipes/assets/325588/4a1e4fa0-860d-42b4-8771-4da0aae6c0a9)
