### PR TITLE
cleanup: Remove ItemDuct support from rendering state

### DIFF
--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -182,16 +182,6 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                 }
                 pos.moveForward(item.output, fPos - 0.5F);
             }
-            if (pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.input.getOpposite())) {
-                boxScale = (fPos * (1 - 0.65)) + 0.65;
-            }
-            if (pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.output)) {
-                boxScale = ((1 - fPos) * (1 - 0.65)) + 0.65;
-            }
-            if (pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.input.getOpposite())
-                    && pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.output)) {
-                boxScale = 0.65;
-            }
 
             if (item.getItemIdentifierStack() == null) {
                 continue;

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
@@ -801,8 +801,7 @@ public class LogisticsNewRenderPipe {
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
             if (renderState.pipeConnectionMatrix.isConnected(dir)) {
                 connectionCount++;
-                if (renderState.pipeConnectionMatrix.isBCConnected(dir)
-                        || renderState.pipeConnectionMatrix.isTDConnected(dir)) {
+                if (renderState.pipeConnectionMatrix.isBCConnected(dir)) {
                     I3DOperation[] texture = new I3DOperation[] { LogisticsNewRenderPipe.basicTexture };
                     if (renderState.textureMatrix.isRouted()) {
                         if (renderState.textureMatrix.isRoutedInDir(dir)) {

--- a/src/main/java/logisticspipes/renderer/state/ConnectionMatrix.java
+++ b/src/main/java/logisticspipes/renderer/state/ConnectionMatrix.java
@@ -11,7 +11,6 @@ public class ConnectionMatrix {
 
     private int mask = 0;
     private int isBCPipeMask = 0;
-    private int isTDPipeMask = 0;
     private boolean dirty = false;
 
     public boolean isConnected(ForgeDirection direction) {
@@ -27,7 +26,6 @@ public class ConnectionMatrix {
         }
         if (!value) {
             setBCConnected(direction, false);
-            setTDConnected(direction, false);
         }
     }
 
@@ -40,19 +38,6 @@ public class ConnectionMatrix {
         if (isBCConnected(direction) != value) {
             // invert the direction.ordinal()'th bit of mask
             isBCPipeMask ^= 1 << direction.ordinal();
-            dirty = true;
-        }
-    }
-
-    public boolean isTDConnected(ForgeDirection direction) {
-        // test if the direction.ordinal()'th bit of mask is set
-        return (isTDPipeMask & (1 << direction.ordinal())) != 0;
-    }
-
-    public void setTDConnected(ForgeDirection direction, boolean value) {
-        if (isTDConnected(direction) != value) {
-            // invert the direction.ordinal()'th bit of mask
-            isTDPipeMask ^= 1 << direction.ordinal();
             dirty = true;
         }
     }
@@ -77,7 +62,6 @@ public class ConnectionMatrix {
     public void writeData(LPDataOutputStream data) throws IOException {
         data.writeByte(mask);
         data.writeByte(isBCPipeMask);
-        data.writeByte(isTDPipeMask);
     }
 
     public void readData(LPDataInputStream data) throws IOException {
@@ -91,12 +75,6 @@ public class ConnectionMatrix {
         newMask = data.readByte();
         if (newMask != isBCPipeMask) {
             isBCPipeMask = newMask;
-            dirty = true;
-        }
-
-        newMask = data.readByte();
-        if (newMask != isTDPipeMask) {
-            isTDPipeMask = newMask;
             dirty = true;
         }
     }


### PR DESCRIPTION
Thermal Dynamics support was removed in commit
https://github.com/GTNewHorizons/LogisticsPipes/commit/7c4de66a00e91366ac7294f76aab071be555f7b3.

But there is some leftover bits in the "ConnectionMatrix" that tracks whether ItemDucts are connected. This PR removes those bits.

Fixes szuend/LogisticsPipes#1.