### PR TITLE
refactor: Extract ItemStackRenderer.renderInWorld into new class

### DIFF
--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -13,8 +13,6 @@ import net.minecraft.client.model.ModelSign;
 import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
-import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.init.Blocks;
@@ -57,7 +55,6 @@ import logisticspipes.transport.LPTravelingItem;
 import logisticspipes.transport.PipeFluidTransportLogistics;
 import logisticspipes.transport.PipeTransportLogistics;
 import logisticspipes.utils.item.ItemIdentifierStack;
-import logisticspipes.utils.item.ItemStackRenderer;
 import logisticspipes.utils.tuples.LPPosition;
 import logisticspipes.utils.tuples.Pair;
 
@@ -70,7 +67,7 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
     public static LogisticsNewRenderPipe secondRenderer = new LogisticsNewRenderPipe();
     public static LogisticsNewPipeItemBoxRenderer boxRenderer = new LogisticsNewPipeItemBoxRenderer();
     public static PlayerConfig config;
-    private static final ItemStackRenderer itemRenderer = new ItemStackRenderer(0, 0, 0, false, false, false);
+    private static final TravelingItemRenderer travelingItemRenderer = new TravelingItemRenderer();
     private static final Map<IPipeSignData, GLRenderList> pipeSignRenderListMap = new HashMap<>();
     private static int localItemTestRenderList = -1;
 
@@ -87,20 +84,6 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
         modelSign.signStick.showModel = false;
 
         LogisticsRenderPipe.config = LogisticsPipes.getClientPlayerConfig();
-        RenderItem customRenderItem = new RenderItem() {
-
-            @Override
-            public boolean shouldBob() {
-                return false;
-            }
-
-            @Override
-            public boolean shouldSpreadItems() {
-                return false;
-            }
-        };
-        customRenderItem.setRenderManager(RenderManager.instance);
-        itemRenderer.setRenderItem(customRenderItem);
     }
 
     @Override
@@ -261,9 +244,7 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
         GL11.glTranslated(x, y, z);
         GL11.glScalef(renderScale, renderScale, renderScale);
         GL11.glTranslatef(0.0F, -0.1F, 0.0F);
-        itemRenderer.setItemIdentifierStack(itemIdentifierStack).setWorldObj(worldObj)
-                .setPartialTickTime(partialTickTime);
-        itemRenderer.renderInWorld();
+        travelingItemRenderer.renderInWorld(worldObj, itemIdentifierStack.getItem(), partialTickTime);
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/logisticspipes/renderer/TravelingItemRenderer.java
+++ b/src/main/java/logisticspipes/renderer/TravelingItemRenderer.java
@@ -1,0 +1,53 @@
+package logisticspipes.renderer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockPane;
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.world.World;
+
+import org.lwjgl.opengl.GL11;
+
+import logisticspipes.LogisticsPipes;
+import logisticspipes.utils.item.ItemIdentifier;
+
+/**
+ * This class renders the actual items that travel through the pipes. Since we (ab)use EntityItem's for this, this class
+ * also has a cache to not allocate a fresh EntityItem for each individual travelling box.
+ */
+public class TravelingItemRenderer {
+
+    private final Map<ItemIdentifier, EntityItem> entityCache = new HashMap<>();
+    private final RenderItem renderItem = new RenderItem();
+
+    public TravelingItemRenderer() {
+        renderItem.setRenderManager(RenderManager.instance);
+    }
+
+    public void renderInWorld(World world, ItemIdentifier itemIdentifier, float partialTickTime) {
+        EntityItem entityItem = entityCache.get(itemIdentifier);
+        if (entityItem == null) {
+            entityItem = new EntityItem(world, 0, 0, 0, itemIdentifier.makeNormalStack(1));
+            entityItem.hoverStart = 0;
+            entityCache.put(itemIdentifier, entityItem);
+        }
+
+        Item item = itemIdentifier.item;
+        if (item instanceof ItemBlock) {
+            Block block = ((ItemBlock) item).field_150939_a;
+            if (block instanceof BlockPane) {
+                GL11.glScalef(0.5F, 0.5F, 0.5F);
+            }
+        } else if (item == LogisticsPipes.logisticsRequestTable) {
+            GL11.glScalef(0.5F, 0.5F, 0.5F);
+        }
+
+        renderItem.doRender(entityItem, 0.0d, 0.0d, 0.0d, 0.0F, partialTickTime);
+    }
+}

--- a/src/main/java/logisticspipes/utils/item/ItemStackRenderer.java
+++ b/src/main/java/logisticspipes/utils/item/ItemStackRenderer.java
@@ -10,8 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockPane;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -21,14 +19,12 @@ import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.entity.item.EntityItem;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
 
 import org.lwjgl.opengl.GL11;
 
-import logisticspipes.LogisticsPipes;
 import logisticspipes.utils.Color;
 import logisticspipes.utils.gui.GuiGraphics;
 import logisticspipes.utils.gui.IItemSearch;
@@ -258,39 +254,6 @@ public class ItemStackRenderer {
         }
 
         GL11.glPopAttrib();
-    }
-
-    public void renderInWorld() {
-        assert renderManager != null;
-        assert renderItem != null;
-
-        ItemIdentifier itemId = itemIdentifierStack.getItem();
-        EntityItem entityItem = entityCache.get(itemId);
-        if (entityItem == null) {
-            entityItem = new EntityItem(worldObj, 0, 0, 0, itemId.makeNormalStack(1));
-            entityItem.hoverStart = 0;
-            entityCache.put(itemId, entityItem);
-        }
-
-        boolean changeColor = renderItem.renderWithColor != renderInColor;
-        if (changeColor) {
-            renderItem.renderWithColor = renderInColor;
-        }
-
-        if (itemId.item instanceof ItemBlock) {
-            Block block = ((ItemBlock) itemId.item).field_150939_a;
-            if (block instanceof BlockPane) {
-                GL11.glScalef(0.5F, 0.5F, 0.5F);
-            }
-        } else if (itemId.item == LogisticsPipes.logisticsRequestTable) {
-            GL11.glScalef(0.5F, 0.5F, 0.5F);
-        }
-
-        renderManager.renderEntityWithPosYaw(entityItem, posX, posY, zLevel, 0.0F, partialTickTime);
-
-        if (changeColor) {
-            renderItem.renderWithColor = !renderInColor;
-        }
     }
 
     public enum DisplayAmount {

--- a/src/main/java/logisticspipes/utils/item/ItemStackRenderer.java
+++ b/src/main/java/logisticspipes/utils/item/ItemStackRenderer.java
@@ -6,9 +6,7 @@
 
 package logisticspipes.utils.item;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -18,7 +16,6 @@ import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureManager;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
@@ -56,8 +53,6 @@ public class ItemStackRenderer {
     private boolean renderInColor;
     private World worldObj;
     private float partialTickTime;
-
-    private final Map<ItemIdentifier, EntityItem> entityCache = new HashMap<>();
 
     public ItemStackRenderer(int posX, int posY, float zLevel, boolean renderEffects, boolean ignoreDepth,
             boolean renderInColor) {


### PR DESCRIPTION
The ItemStackRenderer is very stateful and is used in various places for different reasons. This makes it hard to follow what is going on.

This PR extracts the hot 'renderInWorld' function into a separate class. It's invoked for every traveling item to render the item itself in the transport box. The only important bit is that we need an 'EntityItem' cache for performance reasons.

Why can the PR remove the custom 'RenderItem' subclass? Because it was never actually used: 'renderInWorld' invokes a render function on the "RenderManager.instance", which in turn invokes it's own "RenderItem" class, not the custom one. The custom one was never used for "renderInWorld".

Drive-by: We can create an "RenderItem" of our own and invoke it's 'doRender' directly instead of going via the RenderManager, who has to do a lookup in a map.