### PR TITLE
cleanup: Replace 'boxScale' with a flag and remove unused light param

### DIFF
--- a/src/main/java/logisticspipes/proxy/buildcraft/BCLPPipeTransportItemsRenderer.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCLPPipeTransportItemsRenderer.java
@@ -17,7 +17,7 @@ public class BCLPPipeTransportItemsRenderer extends PipeTransportItemsRenderer {
                 if (LogisticsRenderPipe.boxRenderer != null) {
                     ItemIdentifierStack itemIdentifierStack = ItemIdentifierStack
                             .getFromStack(travellingItem.getItemStack());
-                    LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, light, x, y + 0.25, z, 1.0D);
+                    LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, x, y + 0.25, z);
                 }
             }
         }

--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -147,9 +147,6 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
     private void renderSolids(CoreUnroutedPipe pipe, double x, double y, double z, float partialTickTime) {
         GL11.glPushMatrix();
 
-        float light = pipe.container.getWorldObj()
-                .getLightBrightness(pipe.container.xCoord, pipe.container.yCoord, pipe.container.zCoord);
-
         int count = 0;
         for (LPTravelingItem item : pipe.transport.items) {
             if (count >= LogisticsRenderPipe.MAX_ITEMS_TO_RENDER) {
@@ -163,7 +160,6 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
             }
 
             float fPos = item.getPosition() + item.getSpeed() * partialTickTime;
-            double boxScale = 1;
 
             if (fPos < 0.5) {
                 if (item.input == ForgeDirection.UNKNOWN) {
@@ -197,9 +193,8 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                     x + pos.getXD(),
                     y + pos.getYD(),
                     z + pos.getZD(),
-                    light,
                     0.75F,
-                    boxScale,
+                    /* renderTransportBox */ true,
                     partialTickTime);
             count++;
         }
@@ -219,9 +214,8 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                     x + pos.getXD(),
                     y + pos.getYD(),
                     z + pos.getZD(),
-                    light,
                     0.25F,
-                    0,
+                    /* renderTransportBox */ false,
                     partialTickTime);
             count++;
             if (count >= 27) {
@@ -242,9 +236,9 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
     }
 
     public void doRenderItem(ItemIdentifierStack itemIdentifierStack, World worldObj, double x, double y, double z,
-            float light, float renderScale, double boxScale, float partialTickTime) {
-        if (LogisticsRenderPipe.config.isUseNewRenderer() && boxScale != 0) {
-            LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, light, x, y, z, boxScale);
+            float renderScale, boolean renderTransportBox, float partialTickTime) {
+        if (LogisticsRenderPipe.config.isUseNewRenderer() && renderTransportBox) {
+            LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, x, y, z);
         }
 
         GL11.glPushMatrix();

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
@@ -27,8 +27,7 @@ public class LogisticsNewPipeItemBoxRenderer {
     private static final ResourceLocation BLOCKS = new ResourceLocation("textures/atlas/blocks.png");
     private static final Map<FluidIdentifier, int[]> renderLists = new HashMap<>();
 
-    public void doRenderItem(ItemIdentifierStack itemIdentifierStack, float light, double x, double y, double z,
-            double boxScale) {
+    public void doRenderItem(ItemIdentifierStack itemIdentifierStack, double x, double y, double z) {
         if (LogisticsNewRenderPipe.innerTransportBox == null) return;
         GL11.glPushMatrix();
 
@@ -42,14 +41,9 @@ public class LogisticsNewPipeItemBoxRenderer {
             GL11.glEndList();
         }
 
-        GL11.glTranslated(x, y, z);
         Minecraft.getMinecraft().getTextureManager().bindTexture(LogisticsNewPipeItemBoxRenderer.BLOCKS);
-        GL11.glScaled(boxScale, boxScale, boxScale);
-        GL11.glTranslated(-0.5, -0.5, -0.5);
+        GL11.glTranslated(x - 0.5, y - 0.5, z - 0.5);
         GL11.glCallList(renderList);
-        GL11.glTranslated(0.5, 0.5, 0.5);
-        GL11.glScaled(1 / boxScale, 1 / boxScale, 1 / boxScale);
-        GL11.glTranslated(-0.5, -0.5, -0.5);
 
         if (itemIdentifierStack != null && itemIdentifierStack.getItem().item instanceof LogisticsFluidContainer) {
             FluidStack f = SimpleServiceLocator.logisticsFluidManager.getFluidFromContainer(itemIdentifierStack);


### PR DESCRIPTION
'boxScale' is leftover support for ItemDucts. After we removed ThermalDynamics support we can replace 'boxScale' with a simple boolean flag to indicate whether to render the transport box or not.

After removing the glScale calls, we can also simplify the translation logic into a single glTranslate call.

As part of this change we also remove the unused 'light' parameter. We can always re-add it should we want to render the transport box with an applied light value.

Fixes szuend/LogisticsPipes#3