### PR TITLE
refactor: Reduce number of LPPosition allocs in TESR

### DIFF
--- a/src/main/java/logisticspipes/utils/tuples/LPPosition.java
+++ b/src/main/java/logisticspipes/utils/tuples/LPPosition.java
@@ -140,6 +140,13 @@ public class LPPosition {
         return this;
     }
 
+    public LPPosition reset(double x, double y, double z) {
+        xPos = x;
+        yPos = y;
+        zPos = z;
+        return this;
+    }
+
     public void writeToNBT(String prefix, NBTTagCompound nbt) {
         nbt.setDouble(prefix + "xPos", xPos);
         nbt.setDouble(prefix + "yPos", yPos);


### PR DESCRIPTION
This PR adds a 'reset' method to LPPosition. We use it in the pipe TESR to reduce the number of temporary LPPosition objects we allocate. Instead of thousands of instances every couple seconds we just keep one around and reset it over and over again.

This PR also changes the loop that renders traveling items: We move all the checks that would skip rendering a concrete traveling item to the front of the loop, to reduce the amount of unnecessary work.