### PR TITLE
Making extractor Mk1-Mk2 useful

### DIFF
--- a/src/main/java/logisticspipes/modules/ModuleAdvancedExtractor.java
+++ b/src/main/java/logisticspipes/modules/ModuleAdvancedExtractor.java
@@ -140,11 +140,11 @@ public class ModuleAdvancedExtractor extends LogisticsSneakyDirectionModule impl
     }
 
     protected int ticksToAction() {
-        return 100;
+        return 20;
     }
 
     protected int itemsToExtract() {
-        return 1;
+        return 5;
     }
 
     protected int neededEnergy() {

--- a/src/main/java/logisticspipes/modules/ModuleAdvancedExtractorMK2.java
+++ b/src/main/java/logisticspipes/modules/ModuleAdvancedExtractorMK2.java
@@ -18,6 +18,11 @@ public class ModuleAdvancedExtractorMK2 extends ModuleAdvancedExtractor {
     }
 
     @Override
+    protected int itemsToExtract() {
+        return 32;
+    }
+
+    @Override
     protected int neededEnergy() {
         return 8;
     }

--- a/src/main/java/logisticspipes/modules/ModuleExtractor.java
+++ b/src/main/java/logisticspipes/modules/ModuleExtractor.java
@@ -54,11 +54,11 @@ public class ModuleExtractor extends LogisticsSneakyDirectionModule
     public ModuleExtractor() {}
 
     protected int ticksToAction() {
-        return 100;
+        return 20;
     }
 
     protected int itemsToExtract() {
-        return 1;
+        return 5;
     }
 
     protected int neededEnergy() {

--- a/src/main/java/logisticspipes/modules/ModuleExtractorMk2.java
+++ b/src/main/java/logisticspipes/modules/ModuleExtractorMk2.java
@@ -18,6 +18,11 @@ public class ModuleExtractorMk2 extends ModuleExtractor {
     }
 
     @Override
+    protected int itemsToExtract() {
+        return 32;
+    }
+
+    @Override
     protected int neededEnergy() {
         return 7;
     }


### PR DESCRIPTION
with https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/904
with https://github.com/GTNewHorizons/GT5-Unofficial/pull/2746

This is a part of big Logistics Pipes easifying.
Before the extractor pipes Mk1-Mk2 were pretty useless with there advanced version, because they were too slow.
This commit makes change to their speed:

- Extractor Mk1 / Advanced Extractor Mk1: 1 item every 5 sec -> 5 items every sec
- Extractor Mk2 / Advanced Extractor Mk2: 1 item every sec -> 32 items every sec

Without changes:
- Extractor Mk3 / Advanced Extractor Mk3: 1280 items every sec (64 items every tick).
