### PR TITLE
nuke ic2 recipes

### DIFF
--- a/src/main/java/logisticspipes/proxy/ic2/IC2Proxy.java
+++ b/src/main/java/logisticspipes/proxy/ic2/IC2Proxy.java
@@ -1,6 +1,5 @@
 package logisticspipes.proxy.ic2;
 
-import cpw.mods.fml.common.Loader;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -8,6 +7,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.common.Loader;
 import ic2.api.energy.event.EnergyTileLoadEvent;
 import ic2.api.energy.event.EnergyTileUnloadEvent;
 import ic2.api.energy.tile.IEnergySink;

--- a/src/main/java/logisticspipes/proxy/ic2/IC2Proxy.java
+++ b/src/main/java/logisticspipes/proxy/ic2/IC2Proxy.java
@@ -1,5 +1,6 @@
 package logisticspipes.proxy.ic2;
 
+import cpw.mods.fml.common.Loader;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -129,6 +130,9 @@ public class IC2Proxy implements IIC2Proxy {
      */
     @Override
     public void addCraftingRecipes(ICraftingParts parts) {
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
         if (!Configs.ENABLE_BETA_RECIPES) {
             Recipes.advRecipes.addRecipe(
                     new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ELECTRICBUFFER),


### PR DESCRIPTION
Prevents adding recipes into the IC2 recipes maps when we have dreamcraft loaded