### PR TITLE
Optifine fix

### DIFF
--- a/src/main/java/logisticspipes/LogisticsPipes.java
+++ b/src/main/java/logisticspipes/LogisticsPipes.java
@@ -287,7 +287,7 @@ public class LogisticsPipes {
     private static PlayerConfig playerConfig;
 
     public static boolean isGTNH = false;
-    public static boolean hasGTNHLib = false;
+    public static boolean enableVBO = false;
 
     @EventHandler
     public void init(FMLInitializationEvent event) {
@@ -338,7 +338,11 @@ public class LogisticsPipes {
     public void preInit(FMLPreInitializationEvent evt) {
         // Gregtech New Horizons compat
         isGTNH = Loader.isModLoaded("dreamcraft") && Loader.isModLoaded("gregtech");
-        hasGTNHLib = isGTNH || Loader.isModLoaded("gtnhlib");
+        enableVBO = Loader.isModLoaded("gtnhlib");
+        try {
+            Class.forName("optifine.OptiFineForgeTweaker");
+            enableVBO = false;
+        } catch (ClassNotFoundException ignored) {}
 
         LogisticsPipes.log = evt.getModLog();
         loadClasses();

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemRenderer.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemRenderer.java
@@ -56,14 +56,14 @@ public class LogisticsNewPipeItemRenderer implements IItemRenderer {
             int renderList = lItem.getNewPipeRenderList();
 
             if (renderList == -1) {
-                if (LogisticsPipes.hasGTNHLib) {
+                if (LogisticsPipes.enableVBO) {
                     renderList = buildVBO(lItem);
                 } else {
                     renderList = buildDisplayList(lItem);
                 }
             }
 
-            if (LogisticsPipes.hasGTNHLib) {
+            if (LogisticsPipes.enableVBO) {
                 VBOManager.get(renderList).render();
             } else {
                 GL11.glCallList(renderList);


### PR DESCRIPTION
Optifine generally hates the capturing tesselator, so now default back to gl display lists if detected.