### PR TITLE
Fix for mouse wheel not working on Wayland

### DIFF
--- a/src/main/java/logisticspipes/gui/popup/GuiAddMacro.java
+++ b/src/main/java/logisticspipes/gui/popup/GuiAddMacro.java
@@ -129,7 +129,7 @@ public class GuiAddMacro extends SubGuiScreen implements IItemSearch {
 
     @Override
     public void handleMouseInputSub() {
-        int wheel = org.lwjgl.input.Mouse.getDWheel() / 120;
+        int wheel = org.lwjgl.input.Mouse.getDWheel();
         if (wheel == 0) {
             super.handleMouseInputSub();
         }

--- a/src/main/java/logisticspipes/gui/popup/GuiDiskPopup.java
+++ b/src/main/java/logisticspipes/gui/popup/GuiDiskPopup.java
@@ -174,7 +174,7 @@ public class GuiDiskPopup extends SubGuiScreen {
 
     @Override
     public void handleMouseInputSub() {
-        int wheel = org.lwjgl.input.Mouse.getDWheel() / 120;
+        int wheel = org.lwjgl.input.Mouse.getDWheel();
         if (wheel == 0) {
             super.handleMouseInputSub();
         }

--- a/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
+++ b/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
@@ -341,7 +341,7 @@ public class ItemDisplay {
     public void handleMouse() {
         boolean isShift = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
         boolean isControl = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
-        int wheel = Mouse.getEventDWheel() / 120;
+        int wheel = Mouse.getEventDWheel();
         if (wheel == 0) {
             return;
         }


### PR DESCRIPTION
Current code was assuming that the mouse wheel events always come in increments of 120, thus ignoring everything that is less than that. On Wayland mouse wheel events send values of -1, 0, and +1 (at least in my case), and therefore mouse wheel didn't work at all. This fix should function correctly on both Windows and Linux with Wayland. I don't have Windows so I haven't tested it so it would be nice if someone else could confirm that it still works there.

Relevant information:
https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.control.mousewheel?view=windowsdesktop-9.0#remarks
