### PR TITLE
Fixing NoSuchMethodError in PipeFluidSupplierMk2.addUIWidget()

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,9 +3,11 @@
 dependencies {
     api('com.github.GTNewHorizons:BuildCraft:7.1.42:dev')
 
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.140:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.140:dev') {
+        exclude group: 'com.github.GTNewHorizons', module: 'ModularUI2'
+    }
     implementation('com.github.GTNewHorizons:NotEnoughItems:2.7.29-GTNH:dev')
-    implementation('com.github.GTNewHorizons:ModularUI2:2.2.4-1.7.10:dev')
+    implementation('com.github.GTNewHorizons:ModularUI2:2.1.16-1.7.10:dev')
     implementation('com.github.GTNewHorizons:CodeChickenLib:1.3.0:dev')
 
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.11.8-GTNH:api') { transitive = false }


### PR DESCRIPTION
This commit fixes the following exception:
java.lang.NoSuchMethodError: 'com.cleanroommc.modularui.api.widget.IParentWidget com.cleanroommc.modularui.widgets.layout.Flow.child(com.cleanroommc.modularui.api.widget.IWidget)'
        at Launch//logisticspipes.pipes.PipeFluidSupplierMk2.addUIWidgets(PipeFluidSupplierMk2.java:63)
        ...

To reproduce, right click with a wrench on a Fluid Supplier Pipe.

The problem is caused by compiling against ModularUI2 2.2.4, and running with 2.1.6 in the 2.7.3 version of the pack.

Between the 2.1.6 and 2.2.4 versions of ModularUI2, the child(...) method has been moved from the ParentWidget class to the default implementation of the IParentWidget interface.

https://github.com/GTNewHorizons/ModularUI2/pull/20/files#diff-575ca0bfb40bfc036fdf07466e3efbd83e4c50f9b40799ace9ea23e45e98a143R11

So compiling against both version works because syntactically both versions can be called the same way. However, at runtime one is trying to call ParendWidget.child(...), and the other IParentWidger.child(...).