### PR TITLE
Fix memory leak in server packet decompressor

### DIFF
--- a/src/main/java/logisticspipes/ticks/ServerPacketBufferHandlerThread.java
+++ b/src/main/java/logisticspipes/ticks/ServerPacketBufferHandlerThread.java
@@ -187,6 +187,16 @@ public class ServerPacketBufferHandlerThread {
                     }
                 }
             } while (flag);
+
+            synchronized (playersToClear) {
+                EntityPlayer player;
+                do {
+                    player = playersToClear.poll();
+                    if (player != null) {
+                        ByteBuffer.remove(player);
+                    }
+                } while (player != null);
+            }
         }
 
         @Override
@@ -254,15 +264,6 @@ public class ServerPacketBufferHandlerThread {
                             queue.wait();
                         } catch (InterruptedException ignored) {}
                     }
-                }
-                synchronized (playersToClear) {
-                    EntityPlayer player;
-                    do {
-                        player = playersToClear.poll();
-                        if (player != null) {
-                            ByteBuffer.remove(player);
-                        }
-                    } while (player != null);
                 }
             }
         }


### PR DESCRIPTION
Since the `while (queue.size() == 0)` loop never completes while there are no players online, the "playersToClear" queue never gets polled on a singleplayer server, resulting in LogisticPipes keeping the reference to EntityPlayer (and thus, the entire singleplayer world) even after leaving the game:
![image](https://github.com/user-attachments/assets/c0bb2fd9-7323-4cae-85ee-ced6ee93bdbe)
