### PR TITLE
Fix: Client crashes when inserting renamed crafting module into chassis.

### DIFF
--- a/src/main/java/logisticspipes/logisticspipes/ItemModuleInformationManager.java
+++ b/src/main/java/logisticspipes/logisticspipes/ItemModuleInformationManager.java
@@ -79,7 +79,6 @@ public class ItemModuleInformationManager {
         }
     }
 
-
     /**
      * Remove mod-specific NBT tags from the given ItemStack.
      */

--- a/src/main/java/logisticspipes/logisticspipes/ItemModuleInformationManager.java
+++ b/src/main/java/logisticspipes/logisticspipes/ItemModuleInformationManager.java
@@ -1,11 +1,12 @@
 package logisticspipes.logisticspipes;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
@@ -78,21 +79,23 @@ public class ItemModuleInformationManager {
         }
     }
 
-    public static void removeInformation(ItemStack itemStack) {
-        if (itemStack == null) {
+
+    /**
+     * Remove mod-specific NBT tags from the given ItemStack.
+     */
+    public static void removeInformation(final ItemStack itemStack) {
+        if (itemStack == null || !itemStack.hasTagCompound()) {
             return;
         }
-        if (itemStack.hasTagCompound()) {
-            NBTTagCompound nbt = itemStack.getTagCompound();
+
+        final NBTTagCompound nbtCopy = new NBTTagCompound();
+        for (Object e : itemStack.getTagCompound().tagMap.entrySet()) {
             @SuppressWarnings("unchecked")
-            Collection<String> collection = nbt.tagMap.keySet();
-            nbt = new NBTTagCompound();
-            for (String key : collection) {
-                if (!ItemModuleInformationManager.Filter.contains(key)) {
-                    nbt.setTag(key, nbt.getTag(key));
-                }
+            final Map.Entry<String, NBTBase> entry = (Map.Entry<String, NBTBase>) e;
+            if (!ItemModuleInformationManager.Filter.contains(entry.getKey())) {
+                nbtCopy.setTag(entry.getKey(), entry.getValue());
             }
-            itemStack.setTagCompound(nbt);
         }
+        itemStack.setTagCompound(nbtCopy);
     }
 }


### PR DESCRIPTION
How to reproduce:
1. Rename any crafting module in an anvil.
2. Insert the module into any chassis.
3. Have a nice crash

LogisticsPipes removes mod-specific NBT tags from the module in the process of inserting it into a chassis. The method has a bug which set all the non mod-specific tags' values to null. This upsets Minecraft when copying the said NBT tags later in the process.

The exception:
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.nbt.NBTBase.func_74737_b()" because "nbtBase" is null
    at logisticspipes.utils.FinalNBTTagCompound.copy(FinalNBTTagCompound.java:34)
    at logisticspipes.utils.item.ItemIdentifier.getOrCreateTag(ItemIdentifier.java:332)
    at logisticspipes.utils.item.ItemIdentifier.get(ItemIdentifier.java:357)
    at logisticspipes.utils.item.ItemIdentifier.get(ItemIdentifier.java:382)
    at logisticspipes.utils.item.ItemIdentifierStack.getFromStack(ItemIdentifierStack.java:33)
    at logisticspipes.utils.item.ItemIdentifierInventory.setInventorySlotContents(ItemIdentifierInventory.java:129)
    at logisticspipes.pipes.PipeLogisticsChassi.InventoryChanged(PipeLogisticsChassi.java:369)
    at logisticspipes.pipes.PipeLogisticsChassi.tryInsertingModule(PipeLogisticsChassi.java:433)
    at logisticspipes.pipes.PipeLogisticsChassi.handleClick(PipeLogisticsChassi.java:463)
    at logisticspipes.pipes.basic.CoreRoutedPipe.blockActivated(CoreRoutedPipe.java:920)
    at logisticspipes.pipes.basic.LogisticsBlockGenericPipe.onBlockActivated(LogisticsBlockGenericPipe.java:828)
    at net.minecraft.server.management.ItemInWorldManager.activateBlockOrUseItem(ItemInWorldManager.java:376)
    at net.minecraft.network.NetHandlerPlayServer.processPlayerBlockPlacement(NetHandlerPlayServer.java:556)
    at net.minecraft.network.play.client.C08PacketPlayerBlockPlacement.processPacket(SourceFile:60)
    at net.minecraft.network.play.client.C08PacketPlayerBlockPlacement.processPacket(SourceFile:9)
    at net.minecraft.network.NetworkManager.processReceivedPackets(NetworkManager.java:212)
    at net.minecraft.network.NetworkSystem.networkTick(NetworkSystem.java:165)
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:659)
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:547)
    at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:111)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
    at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)

```