### PR TITLE
Search in the contents of Universal Fluid Cells

### DIFF
--- a/src/main/java/logisticspipes/gui/orderer/GuiOrderer.java
+++ b/src/main/java/logisticspipes/gui/orderer/GuiOrderer.java
@@ -13,6 +13,10 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.input.Keyboard;
 
@@ -152,6 +156,22 @@ public abstract class GuiOrderer extends LogisticsBaseGuiScreen implements IItem
     public boolean itemSearched(ItemIdentifier item) {
         if (search.isEmpty()) {
             return true;
+        }
+        if (item.tag != null && "IC2".equals(item.getModName())
+                && "itemFluidCell".equals(item.item.getUnlocalizedName())) {
+            if (item.tag.hasKey("Fluid")) {
+                final NBTTagCompound fluidTag = item.tag.getCompoundTag("Fluid");
+                if (fluidTag.hasKey("FluidName") && fluidTag.hasKey("Amount")) {
+                    final String fluidName = fluidTag.getString("FluidName");
+                    final int fluidAmount = fluidTag.getInteger("Amount");
+                    final Fluid fluid = FluidRegistry.getFluid(fluidName);
+                    if (isSearched(
+                            fluid.getLocalizedName(new FluidStack(fluid, fluidAmount)).toLowerCase(Locale.US),
+                            search.getContent().toLowerCase(Locale.US))) {
+                        return true;
+                    }
+                }
+            }
         }
         if (isSearched(item.getFriendlyName().toLowerCase(Locale.US), search.getContent().toLowerCase(Locale.US))) {
             return true;

--- a/src/main/java/logisticspipes/gui/orderer/GuiRequestTable.java
+++ b/src/main/java/logisticspipes/gui/orderer/GuiRequestTable.java
@@ -17,6 +17,10 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
@@ -683,6 +687,22 @@ public class GuiRequestTable extends LogisticsBaseGuiScreen
     public boolean itemSearched(ItemIdentifier item) {
         if (search.isEmpty()) {
             return true;
+        }
+        if (item.tag != null && "IC2".equals(item.getModName())
+                && "itemFluidCell".equals(item.item.getUnlocalizedName())) {
+            if (item.tag.hasKey("Fluid")) {
+                final NBTTagCompound fluidTag = item.tag.getCompoundTag("Fluid");
+                if (fluidTag.hasKey("FluidName") && fluidTag.hasKey("Amount")) {
+                    final String fluidName = fluidTag.getString("FluidName");
+                    final int fluidAmount = fluidTag.getInteger("Amount");
+                    final Fluid fluid = FluidRegistry.getFluid(fluidName);
+                    if (isSearched(
+                            fluid.getLocalizedName(new FluidStack(fluid, fluidAmount)).toLowerCase(Locale.US),
+                            search.getContent().toLowerCase(Locale.US))) {
+                        return true;
+                    }
+                }
+            }
         }
         if (isSearched(item.getFriendlyName().toLowerCase(Locale.US), search.getContent().toLowerCase(Locale.US))) {
             return true;


### PR DESCRIPTION
Reasoning: Currently Universal Fluid Cells is a very convenient way to store small amounts of liquids and gasses in early game. Unfortunately, LP search does not allow finding those by the liquid/gas name, which makes it very cumbersome to store in the LP networks.

I know that my implementation creates a copy-pasta in 2 places, but unfortunately this is how the current code is structured. I didn't want to break this delicate structure for such a small change.

It would be better to refactor the whole search logic so that it is consolidated in one place. I have a bunch of other QOL improvement ideas related to search (i.e. @mod, "search with spaces", etc). So I would rather do the refactoring before implementing those.