### PR TITLE
Render crafting result of ModuleCrafter(MK2/MK3) item on sneak

### DIFF
--- a/src/main/java/logisticspipes/LogisticsPipes.java
+++ b/src/main/java/logisticspipes/LogisticsPipes.java
@@ -132,6 +132,7 @@ import logisticspipes.recipes.CraftingPermissionManager;
 import logisticspipes.recipes.RecipeManager;
 import logisticspipes.recipes.SolderingStationRecipes;
 import logisticspipes.renderer.FluidContainerRenderer;
+import logisticspipes.renderer.ItemModuleRenderer;
 import logisticspipes.renderer.LogisticsHUDRenderer;
 import logisticspipes.renderer.LogisticsPipeItemRenderer;
 import logisticspipes.routing.RouterManager;
@@ -494,6 +495,9 @@ public class LogisticsPipes {
         LogisticsPipes.ModuleItem.setUnlocalizedName("itemModule");
         LogisticsPipes.ModuleItem.loadModules();
         GameRegistry.registerItem(LogisticsPipes.ModuleItem, LogisticsPipes.ModuleItem.getUnlocalizedName());
+        if (isClient) {
+            MinecraftForgeClient.registerItemRenderer(LogisticsPipes.ModuleItem, new ItemModuleRenderer());
+        }
 
         LogisticsPipes.LogisticsItemDisk = new ItemDisk();
         LogisticsPipes.LogisticsItemDisk.setUnlocalizedName("itemDisk");

--- a/src/main/java/logisticspipes/items/ItemModule.java
+++ b/src/main/java/logisticspipes/items/ItemModule.java
@@ -422,4 +422,10 @@ public class ItemModule extends LogisticsItem {
             StringUtils.addShiftAddition(itemStack, list);
         }
     }
+
+    public static boolean isCrafter(ItemStack itemStack) {
+        return itemStack.getItem() instanceof ItemModule && (itemStack.getItemDamage() == ItemModule.CRAFTER
+                || itemStack.getItemDamage() == ItemModule.CRAFTER_MK2
+                || itemStack.getItemDamage() == ItemModule.CRAFTER_MK3);
+    }
 }

--- a/src/main/java/logisticspipes/renderer/ItemModuleRenderer.java
+++ b/src/main/java/logisticspipes/renderer/ItemModuleRenderer.java
@@ -1,0 +1,60 @@
+package logisticspipes.renderer;
+
+import java.util.Optional;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.IItemRenderer;
+
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.opengl.GL11;
+
+import logisticspipes.items.ItemModule;
+import logisticspipes.modules.ModuleCrafter;
+import logisticspipes.utils.item.EzNBT;
+
+public class ItemModuleRenderer implements IItemRenderer {
+
+    private final RenderItem ri = new RenderItem();
+
+    @Override
+    public boolean handleRenderType(final ItemStack itemStack, final ItemRenderType rendererType) {
+        final boolean isShiftPressed = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)
+                || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+
+        if (isShiftPressed && rendererType == IItemRenderer.ItemRenderType.INVENTORY
+                && ItemModule.isCrafter(itemStack)) {
+            return this.stackToModule(itemStack).map(m -> m.getConfiguredCraftResult()).isPresent();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean shouldUseRenderHelper(final ItemRenderType type, final ItemStack item,
+            final ItemRendererHelper helper) {
+        return false;
+    }
+
+    @Override
+    public void renderItem(final ItemRenderType renderType, final ItemStack itemStack, final Object... data) {
+        final ItemStack is = stackToModule(itemStack).get().getConfiguredCraftResult().makeNormalStack();
+        final Minecraft mc = Minecraft.getMinecraft();
+
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
+        RenderHelper.enableGUIStandardItemLighting();
+        this.ri.renderItemAndEffectIntoGUI(mc.fontRenderer, mc.getTextureManager(), is, 0, 0);
+        RenderHelper.disableStandardItemLighting();
+        GL11.glPopAttrib();
+    }
+
+    protected Optional<ModuleCrafter> stackToModule(final ItemStack itemStack) {
+        return new EzNBT(itemStack).get("moduleInformation").asCompound().map(modInfoTag -> {
+            final ModuleCrafter module = new ModuleCrafter();
+            module.readFromNBT(modInfoTag);
+            return module;
+        });
+    }
+}

--- a/src/main/java/logisticspipes/utils/item/EzNBT.java
+++ b/src/main/java/logisticspipes/utils/item/EzNBT.java
@@ -1,0 +1,192 @@
+package logisticspipes.utils.item;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagInt;
+import net.minecraft.nbt.NBTTagString;
+
+public class EzNBT {
+
+    private static EzNBT NOTHING = new EzNBT((NBTBase) null);
+
+    protected final Optional<NBTBase> base;
+    protected final Kind kind;
+
+    public EzNBT(final NBTBase base) {
+        this.base = Optional.ofNullable(base);
+        this.kind = Kind.determine(base)
+                .orElseThrow(() -> new IllegalArgumentException("Unknow NBT Tag Type: " + base.getId()));
+    }
+
+    public EzNBT(final ItemStack stack) {
+        this(stack.getTagCompound());
+    }
+
+    public EzNBT get(final String key) {
+        if (this.kind != Kind.COMPOUND) {
+            return EzNBT.NOTHING;
+        }
+        return new EzNBT(asCompound().get().getTag(key));
+    }
+
+    public Optional<String> valueString() {
+        if (this.kind != Kind.STRING) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(asString().get().func_150285_a_());
+    }
+
+    public Optional<String> getString(final String key) {
+        if (this.kind != Kind.COMPOUND) {
+            return Optional.empty();
+        }
+        final NBTTagCompound compound = asCompound().get();
+        if (!compound.hasKey(key)) {
+            // This special key is here becasue when using the NBTTagCompound.getString()
+            // directly there is no way to determine if the key is absent or set to an empty string
+            return Optional.empty();
+        }
+        return Optional.of(compound.getString(key));
+    }
+
+    public Optional<Integer> valueInteger() {
+        if (this.kind != Kind.STRING) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(asInteger().get().func_150287_d());
+    }
+
+    public Optional<Integer> getInteger(final String key) {
+        if (this.kind != Kind.COMPOUND) {
+            return Optional.empty();
+        }
+        final NBTTagCompound compound = asCompound().get();
+        if (!compound.hasKey(key)) {
+            // This special key is here becasue when using the NBTTagCompound.getInteger()
+            // directly there is no way to determine if the key is absent or set to 0
+            return Optional.empty();
+        }
+        return Optional.of(compound.getInteger(key));
+    }
+
+    public boolean hasAll(final String... keys) {
+        if (this.kind != Kind.COMPOUND || keys.length == 0) {
+            return false;
+        }
+        final NBTTagCompound self = this.asCompound().get();
+        for (String tested : keys) {
+            if (!self.hasKey(tested)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean hasAny(final String... keys) {
+        if (this.kind != Kind.COMPOUND || keys.length == 0) {
+            return false;
+        }
+        final NBTTagCompound self = this.asCompound().get();
+        for (String tested : keys) {
+            if (self.hasKey(tested)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isPresent() {
+        return this.base.isPresent();
+    }
+
+    public boolean isEmpty() {
+        return !isPresent();
+    }
+
+    public void ifPresent(final Consumer<NBTTagCompound> fn) {
+        if (this.isPresent()) {
+            if (this.kind != Kind.COMPOUND) {
+                final String msg = String.format(
+                        "The tag is present but has an incorrect type. Expected: {}, found: {}",
+                        Kind.COMPOUND.name(),
+                        this.kind.name());
+                throw new IllegalArgumentException(msg);
+            }
+            fn.accept((NBTTagCompound) this.base.get());
+        }
+    }
+
+    public boolean hasKey(final String key) {
+        if (this.kind != Kind.COMPOUND) {
+            return false;
+        }
+        return asCompound().get().hasKey(key);
+    }
+
+    public Optional<NBTTagCompound> asCompound() {
+        if (this.kind != Kind.COMPOUND) {
+            return Optional.empty();
+        }
+        return this.base.map(it -> (NBTTagCompound) it);
+    }
+
+    public Optional<NBTTagString> asString() {
+        if (this.kind != Kind.STRING) {
+            return Optional.empty();
+        }
+        return this.base.map(it -> (NBTTagString) it);
+    }
+
+    public Optional<NBTTagInt> asInteger() {
+        if (this.kind != Kind.INT) {
+            return Optional.empty();
+        }
+        return this.base.map(it -> (NBTTagInt) it);
+    }
+
+    public enum Kind {
+
+        NOTHING(-1, "NOTHING"),
+        END(0, NBTBase.NBTTypes[0]),
+        BYTE(1, NBTBase.NBTTypes[1]),
+        SHORT(2, NBTBase.NBTTypes[2]),
+        INT(3, NBTBase.NBTTypes[3]),
+        LONG(4, NBTBase.NBTTypes[4]),
+        FLOAT(5, NBTBase.NBTTypes[5]),
+        DOUBLE(6, NBTBase.NBTTypes[6]),
+        BYTE_ARRAY(7, NBTBase.NBTTypes[7]),
+        STRING(8, NBTBase.NBTTypes[8]),
+        LIST(9, NBTBase.NBTTypes[9]),
+        COMPOUND(10, NBTBase.NBTTypes[10]),
+        INT_ARRAY(11, NBTBase.NBTTypes[11]);
+
+        private int id;
+        private String _name;
+
+        static Optional<Kind> determine(final NBTBase base) {
+            if (base == null) {
+                return Optional.of(NOTHING);
+            }
+            final int baseId = base.getId();
+            return Stream.of(Kind.values()).filter(it -> it.getId() == baseId).findAny();
+        }
+
+        Kind(final int id, final String name) {
+            this.id = id;
+            this._name = name;
+        }
+
+        int getId() {
+            return this.id;
+        }
+
+        String getName() {
+            return this._name;
+        }
+    }
+}


### PR DESCRIPTION
ItemModuleRenderer class implements rendering of the crafting target for a ModuleCrafter. I took this class from AE2 and adapted for LP logic.

It only works for the modules in inventory, and not for the ones inserted into chassis. Some work need to be done to also enable it for the chassis.

Currently it greatly improves the experience of managing a bunch of Crafter modules. It is not anymore necessary to open or hover mouse over each module individually to understand what Crater modules are supposed to produce.

EzNBT class is my attempt at making a tiny API to simplify working with NBT. The intention is to protect the client from NPE's, and make the client code easier to read, more functional style (and shorter, preferably). Reading a non-existing key would not lead to any exception, but the functions that return actual values, or the Minecraft's NBT classses (NBTBase) would force the client to test for it's existence using java.util.Optional.

The API is still half-baked, and does not have any JavaDoc. I am very new to Minecraft modding, so I'd be happy to get some feedback, if it is a good direction in general, and if maybe there are already things that help with NBT. If it is worth working on further, I will add the handling of missing NBT types, JavaDoc and reasonable amount of Unit Testing.