### PR TITLE
issue 17194. Fix integration ModuleExtractor and drawers

### DIFF
--- a/src/main/java/logisticspipes/modules/ModuleExtractor.java
+++ b/src/main/java/logisticspipes/modules/ModuleExtractor.java
@@ -155,7 +155,7 @@ public class ModuleExtractor extends LogisticsSneakyDirectionModule
         for (int i = 0; i < targetUtil.getSizeInventory(); i++) {
 
             ItemStack slot = targetUtil.getStackInSlot(i);
-            if (slot == null) {
+            if (slot == null || slot.stackSize == 0) {
                 continue;
             }
             ItemIdentifier slotitem = ItemIdentifier.get(slot);
@@ -193,7 +193,7 @@ public class ModuleExtractor extends LogisticsSneakyDirectionModule
                     break;
                 }
                 slot = targetUtil.getStackInSlot(i);
-                if (slot == null) {
+                if (slot == null || slot.stackSize == 0) {
                     break;
                 }
                 jamList.add(reply.getValue1());


### PR DESCRIPTION
[issue ](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17194)fix. Fix integration ModuleExtractor and drawers

### Problem
When 2x2 or 1x2 drawer is locked ModuleExtractor extract items only from first slot. When ModuleExtractor code check item existence in inventory slot its use [condition ](https://github.com/GTNewHorizons/LogisticsPipes/blob/master/src/main/java/logisticspipes/modules/ModuleExtractor.java#L158)`targetUtil.getStackInSlot(i) != null`, but condition is incomplete for locked drawers, because func `targetUtil.getStackInSlot(i)` can return `ItemStack `with empty `stackSize` for locked drawers

### Fix
When checking item existence in inventory slot condition should be: `targetUtil.getStackInSlot(i)` is not null **and not empty**