### PR TITLE
Replace the search bar in logistics request table

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     api('com.github.GTNewHorizons:BuildCraft:7.1.42:dev')
 
     implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.227:dev')
-    implementation('com.github.GTNewHorizons:CodeChickenCore:1.1.10:dev')
+
 
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.11.13-GTNH:api') { transitive = false }
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-580-GTNH:api') { transitive = false }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,8 +4,7 @@ dependencies {
     api('com.github.GTNewHorizons:BuildCraft:7.1.42:dev')
 
     implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.227:dev')
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev')
-    implementation('com.github.GTNewHorizons:CodeChickenLib:1.3.0:dev')
+    implementation('com.github.GTNewHorizons:CodeChickenCore:1.1.10:dev')
 
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.11.13-GTNH:api') { transitive = false }
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-580-GTNH:api') { transitive = false }

--- a/src/main/java/logisticspipes/gui/orderer/GuiOrderer.java
+++ b/src/main/java/logisticspipes/gui/orderer/GuiOrderer.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import logisticspipes.utils.gui.ISearchBar;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -45,7 +46,7 @@ public abstract class GuiOrderer extends LogisticsBaseGuiScreen implements IItem
 
     public final EntityPlayer _entityPlayer;
     public ItemDisplay itemDisplay;
-    private SearchBar search;
+    private ISearchBar search;
 
     protected String _title = "Request items";
 

--- a/src/main/java/logisticspipes/gui/orderer/GuiOrderer.java
+++ b/src/main/java/logisticspipes/gui/orderer/GuiOrderer.java
@@ -9,7 +9,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import logisticspipes.utils.gui.ISearchBar;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -34,6 +33,7 @@ import logisticspipes.utils.gui.DummyContainer;
 import logisticspipes.utils.gui.GuiCheckBox;
 import logisticspipes.utils.gui.GuiGraphics;
 import logisticspipes.utils.gui.IItemSearch;
+import logisticspipes.utils.gui.ISearchBar;
 import logisticspipes.utils.gui.ISubGuiControler;
 import logisticspipes.utils.gui.ItemDisplay;
 import logisticspipes.utils.gui.LogisticsBaseGuiScreen;

--- a/src/main/java/logisticspipes/gui/orderer/GuiRequestTable.java
+++ b/src/main/java/logisticspipes/gui/orderer/GuiRequestTable.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import logisticspipes.utils.gui.GuiSearchBar;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -56,7 +57,6 @@ import logisticspipes.utils.gui.IItemSearch;
 import logisticspipes.utils.gui.ISubGuiControler;
 import logisticspipes.utils.gui.ItemDisplay;
 import logisticspipes.utils.gui.LogisticsBaseGuiScreen;
-import logisticspipes.utils.gui.SearchBar;
 import logisticspipes.utils.gui.SmallGuiButton;
 import logisticspipes.utils.gui.extention.GuiExtention;
 import logisticspipes.utils.item.ItemIdentifier;
@@ -82,7 +82,7 @@ public class GuiRequestTable extends LogisticsBaseGuiScreen
 
     public final EntityPlayer _entityPlayer;
     public ItemDisplay itemDisplay;
-    private SearchBar search;
+    private GuiSearchBar search;
 
     protected final String _title = "Request items";
 
@@ -188,7 +188,7 @@ public class GuiRequestTable extends LogisticsBaseGuiScreen
 		// @formatter:on
 
         if (search == null) {
-            search = new SearchBar(mc.fontRenderer, this, guiLeft + 205, bottom - 78, 200, 15);
+            search = new GuiSearchBar("search");
         }
         search.reposition(guiLeft + 205, bottom - 78, 200, 15);
 
@@ -773,7 +773,7 @@ public class GuiRequestTable extends LogisticsBaseGuiScreen
 
     @Override
     protected void keyTyped(char c, int i) {
-        if (i == 30 && Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) { // Ctrl-a
+        if (i == 30 && Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) && !search.isFocused()) { // Ctrl-a
             itemDisplay.setMaxAmount();
         } else if (i == 32 && Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) { // Ctrl-d
             itemDisplay.resetAmount();

--- a/src/main/java/logisticspipes/gui/orderer/GuiRequestTable.java
+++ b/src/main/java/logisticspipes/gui/orderer/GuiRequestTable.java
@@ -9,7 +9,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import logisticspipes.utils.gui.GuiSearchBar;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -53,6 +52,7 @@ import logisticspipes.utils.Color;
 import logisticspipes.utils.gui.DummyContainer;
 import logisticspipes.utils.gui.GuiCheckBox;
 import logisticspipes.utils.gui.GuiGraphics;
+import logisticspipes.utils.gui.GuiSearchBar;
 import logisticspipes.utils.gui.IItemSearch;
 import logisticspipes.utils.gui.ISubGuiControler;
 import logisticspipes.utils.gui.ItemDisplay;

--- a/src/main/java/logisticspipes/gui/popup/GuiAddTracking.java
+++ b/src/main/java/logisticspipes/gui/popup/GuiAddTracking.java
@@ -5,7 +5,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import logisticspipes.utils.gui.ISearchBar;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.enchantment.Enchantment;
@@ -21,6 +20,7 @@ import logisticspipes.proxy.MainProxy;
 import logisticspipes.utils.gui.GuiCheckBox;
 import logisticspipes.utils.gui.GuiGraphics;
 import logisticspipes.utils.gui.IItemSearch;
+import logisticspipes.utils.gui.ISearchBar;
 import logisticspipes.utils.gui.ItemDisplay;
 import logisticspipes.utils.gui.SearchBar;
 import logisticspipes.utils.gui.SmallGuiButton;

--- a/src/main/java/logisticspipes/gui/popup/GuiAddTracking.java
+++ b/src/main/java/logisticspipes/gui/popup/GuiAddTracking.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import logisticspipes.utils.gui.ISearchBar;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.enchantment.Enchantment;
@@ -33,7 +34,7 @@ public class GuiAddTracking extends SubGuiScreen implements IItemSearch {
     private final String PREFIX = "gui.networkstatistics.add.";
 
     ItemDisplay itemDisplay;
-    SearchBar search;
+    ISearchBar search;
     private final LogisticsStatisticsTileEntity tile;
 
     public GuiAddTracking(LogisticsStatisticsTileEntity tile) {

--- a/src/main/java/logisticspipes/utils/gui/GuiSearchBar.java
+++ b/src/main/java/logisticspipes/utils/gui/GuiSearchBar.java
@@ -1,10 +1,10 @@
 package logisticspipes.utils.gui;
 
-import codechicken.nei.TextField;
 import org.lwjgl.input.Mouse;
 
+import codechicken.nei.TextField;
 
-public class GuiSearchBar extends TextField implements ISearchBar  {
+public class GuiSearchBar extends TextField implements ISearchBar {
 
     public GuiSearchBar(String ident) {
         super(ident);
@@ -37,7 +37,6 @@ public class GuiSearchBar extends TextField implements ISearchBar  {
     public String getContent() {
         return text();
     }
-
 
     @Override
     public void onTextChange(String oldText) {

--- a/src/main/java/logisticspipes/utils/gui/GuiSearchBar.java
+++ b/src/main/java/logisticspipes/utils/gui/GuiSearchBar.java
@@ -1,0 +1,51 @@
+package logisticspipes.utils.gui;
+
+import codechicken.nei.TextField;
+import org.lwjgl.input.Mouse;
+
+
+public class GuiSearchBar extends TextField implements ISearchBar  {
+
+    public GuiSearchBar(String ident) {
+        super(ident);
+    }
+
+    @Override
+    public void reposition(int left, int top, int width, int height) {
+        this.x = left;
+        this.y = top;
+        this.w = width;
+        this.h = height;
+    }
+
+    @Override
+    public void renderSearchBar() {
+        draw(Mouse.getX(), Mouse.getY());
+    }
+
+    @Override
+    public boolean isFocused() {
+        return focused();
+    }
+
+    @Override
+    public boolean handleKey(char typedChar, int keyCode) {
+        return handleKeyPress(keyCode, typedChar);
+    }
+
+    @Override
+    public String getContent() {
+        return text();
+    }
+
+
+    @Override
+    public void onTextChange(String oldText) {
+
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return text().isEmpty();
+    }
+}

--- a/src/main/java/logisticspipes/utils/gui/ISearchBar.java
+++ b/src/main/java/logisticspipes/utils/gui/ISearchBar.java
@@ -1,6 +1,7 @@
 package logisticspipes.utils.gui;
 
 public interface ISearchBar {
+
     void reposition(int left, int top, int width, int heigth);
 
     void renderSearchBar();

--- a/src/main/java/logisticspipes/utils/gui/ISearchBar.java
+++ b/src/main/java/logisticspipes/utils/gui/ISearchBar.java
@@ -1,0 +1,17 @@
+package logisticspipes.utils.gui;
+
+public interface ISearchBar {
+    void reposition(int left, int top, int width, int heigth);
+
+    void renderSearchBar();
+
+    boolean handleClick(int x, int y, int k);
+
+    boolean isFocused();
+
+    boolean handleKey(char typedChar, int keyCode);
+
+    String getContent();
+
+    boolean isEmpty();
+}

--- a/src/main/java/logisticspipes/utils/gui/SearchBar.java
+++ b/src/main/java/logisticspipes/utils/gui/SearchBar.java
@@ -11,7 +11,7 @@ import org.lwjgl.input.Keyboard;
 
 import logisticspipes.utils.Color;
 
-public class SearchBar {
+public class SearchBar implements ISearchBar {
 
     public String searchinput1 = "";
     public String searchinput2 = "";
@@ -55,6 +55,7 @@ public class SearchBar {
         this.alignRight = alignRight;
     }
 
+    @Override
     public void reposition(int left, int top, int width, int heigth) {
         this.left = left;
         this.top = top;
@@ -63,6 +64,7 @@ public class SearchBar {
         searchWidth = width - 10;
     }
 
+    @Override
     public void renderSearchBar() {
         if (isFocused()) {
             screen.drawRect(left, top - 2, left + width, top + heigth, Color.BLACK);
@@ -100,6 +102,7 @@ public class SearchBar {
     /**
      * @return Boolean, true if click was handled.
      */
+    @Override
     public boolean handleClick(int x, int y, int k) {
         if (x >= left + 2 && x < left + width - 2 && y >= top && y < top + heigth) {
             focus();
@@ -136,6 +139,7 @@ public class SearchBar {
         isActive = true;
     }
 
+    @Override
     public boolean isFocused() {
         return isActive;
     }
@@ -143,6 +147,7 @@ public class SearchBar {
     /**
      * @return Boolean, true if key was handled.
      */
+    @Override
     public boolean handleKey(char typedChar, int keyCode) {
         if (!isFocused()) {
             return false;
@@ -203,10 +208,12 @@ public class SearchBar {
         return true;
     }
 
+    @Override
     public String getContent() {
         return searchinput1 + searchinput2;
     }
 
+    @Override
     public boolean isEmpty() {
         return searchinput1.isEmpty() && searchinput2.isEmpty();
     }


### PR DESCRIPTION
Currently the search bar does not allow for ctrl+a highlighting of text, holding backspace to delete characters, and other useful textbox functionality. To remedy this, the TextField from NEI was  swapped in.

Also removed CodeChickenLib as an explicit dependency, because it is deprecated now and causes a crash when opening inventory.

![image](https://github.com/user-attachments/assets/16365469-2a89-484b-a2e2-f3b4cb35b779)

Tested in latest nightly: Yes

