### PR TITLE
Re-add Thermal Dynamics compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,6 +23,7 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') { transitive = false }
     compileOnly('curse.maven:computercraft-67504:2269339') { transitive = false }
     compileOnly('curse.maven:cofh-core-69162:2388751') { transitive = false }
+    compileOnly('curse.maven:thermal-dynamics-227443:2388757') { transitive = false }
     compileOnly('curse.maven:thermal-expansion-69163:2388759') { transitive = false }
     compileOnly('curse.maven:better-storage-232919:2731636') { transitive = false }
     compileOnly('org.jetbrains:annotations:26.0.2') { transitive = false }

--- a/src/main/java/logisticspipes/LogisticsPipes.java
+++ b/src/main/java/logisticspipes/LogisticsPipes.java
@@ -379,6 +379,7 @@ public class LogisticsPipes {
 
         SimpleServiceLocator.buildCraftProxy.registerPipeInformationProvider();
         SimpleServiceLocator.buildCraftProxy.initProxy();
+        SimpleServiceLocator.thermalDynamicsProxy.registerPipeInformationProvider();
 
         SimpleServiceLocator.specialpipeconnection.registerHandler(new TeleportPipes());
         SimpleServiceLocator.specialtileconnection.registerHandler(new TesseractConnection());

--- a/src/main/java/logisticspipes/asm/LogisticsPipesLateMixins.java
+++ b/src/main/java/logisticspipes/asm/LogisticsPipesLateMixins.java
@@ -1,11 +1,14 @@
 package logisticspipes.asm;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
 import com.gtnewhorizon.gtnhmixins.LateMixin;
+
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
+import cpw.mods.fml.relauncher.Side;
 
 @LateMixin
 public class LogisticsPipesLateMixins implements ILateMixinLoader {
@@ -17,10 +20,17 @@ public class LogisticsPipesLateMixins implements ILateMixinLoader {
 
     @Override
     public List<String> getMixins(Set<String> loadedMods) {
+        List<String> mixins = new ArrayList<>();
         if (loadedMods.contains("ComputerCraft")) {
-            return Collections.singletonList("computercraft.MixinLuaJLuaMachine");
+            mixins.add("computercraft.MixinLuaJLuaMachine");
         }
-        return Collections.emptyList();
+        if (loadedMods.contains("ThermalDynamics")) {
+            if (FMLLaunchHandler.side() == Side.CLIENT) {
+                mixins.add("thermaldynamics.MixinRenderDuctItems");
+            }
+            mixins.add("thermaldynamics.MixinTileTDBase");
+            mixins.add("thermaldynamics.MixinTravelingItem");
+        }
+        return mixins;
     }
-
 }

--- a/src/main/java/logisticspipes/asm/td/DuctAccessor.java
+++ b/src/main/java/logisticspipes/asm/td/DuctAccessor.java
@@ -1,0 +1,11 @@
+package logisticspipes.asm.td;
+
+import cofh.thermaldynamics.duct.Duct;
+
+public interface DuctAccessor {
+
+    Duct getDuct();
+
+    void setDuct(Duct duct);
+
+}

--- a/src/main/java/logisticspipes/asm/td/RoutingInformationAccessor.java
+++ b/src/main/java/logisticspipes/asm/td/RoutingInformationAccessor.java
@@ -1,0 +1,11 @@
+package logisticspipes.asm.td;
+
+import logisticspipes.routing.ItemRoutingInformation;
+
+public interface RoutingInformationAccessor {
+
+    ItemRoutingInformation getRoutingInformation();
+
+    void setRoutingInformation(ItemRoutingInformation routingInformation);
+
+}

--- a/src/main/java/logisticspipes/mixins/early/minecraft/MixinAddInfoPart.java
+++ b/src/main/java/logisticspipes/mixins/early/minecraft/MixinAddInfoPart.java
@@ -17,15 +17,15 @@ import logisticspipes.asm.addinfo.IAddInfoProvider;
 public class MixinAddInfoPart implements IAddInfoProvider {
 
     @Unique
-    private List<IAddInfo> logisticspipes$additionalInformation;
+    private List<IAddInfo> LogisticsPipes$additionalInformation;
 
     @SuppressWarnings("unchecked")
     @Override
     public <T extends IAddInfo> T getLogisticsPipesAddInfo(Class<T> clazz) {
-        if (this.logisticspipes$additionalInformation == null) {
+        if (this.LogisticsPipes$additionalInformation == null) {
             return null;
         }
-        for (IAddInfo info : this.logisticspipes$additionalInformation) {
+        for (IAddInfo info : this.LogisticsPipes$additionalInformation) {
             if (info != null && info.getClass() == clazz) {
                 return (T) info;
             }
@@ -35,13 +35,13 @@ public class MixinAddInfoPart implements IAddInfoProvider {
 
     @Override
     public void setLogisticsPipesAddInfo(IAddInfo info) {
-        if (this.logisticspipes$additionalInformation == null) {
-            this.logisticspipes$additionalInformation = new ArrayList<>();
+        if (this.LogisticsPipes$additionalInformation == null) {
+            this.LogisticsPipes$additionalInformation = new ArrayList<>();
         }
-        for (int i = 0; i < this.logisticspipes$additionalInformation.size(); i++) {
-            if (this.logisticspipes$additionalInformation.get(i) != null
-                    && this.logisticspipes$additionalInformation.get(i).getClass() == info.getClass()) {
-                this.logisticspipes$additionalInformation.set(i, info);
+        for (int i = 0; i < this.LogisticsPipes$additionalInformation.size(); i++) {
+            if (this.LogisticsPipes$additionalInformation.get(i) != null
+                    && this.LogisticsPipes$additionalInformation.get(i).getClass() == info.getClass()) {
+                this.LogisticsPipes$additionalInformation.set(i, info);
             }
         }
     }

--- a/src/main/java/logisticspipes/mixins/early/minecraft/MixinTileEntity.java
+++ b/src/main/java/logisticspipes/mixins/early/minecraft/MixinTileEntity.java
@@ -17,10 +17,10 @@ import logisticspipes.routing.pathfinder.changedetection.TEControl;
 public class MixinTileEntity implements ILPTEInformation {
 
     @Unique
-    private LPTileEntityObject logisticspipes$informationObject;
+    private LPTileEntityObject LogisticsPipes$informationObject;
 
     @Inject(at = @At("HEAD"), method = "invalidate")
-    private void logisticspipes$invalidate(CallbackInfo ci) {
+    private void LogisticsPipes$invalidate(CallbackInfo ci) {
         try {
             TEControl.invalidate((TileEntity) (Object) this);
         } catch (Exception e) {
@@ -32,7 +32,7 @@ public class MixinTileEntity implements ILPTEInformation {
     }
 
     @Inject(at = @At("HEAD"), method = "validate")
-    private void logisticspipes$validate(CallbackInfo ci) {
+    private void LogisticsPipes$validate(CallbackInfo ci) {
         try {
             TEControl.validate((TileEntity) (Object) this);
         } catch (Exception e) {
@@ -45,11 +45,11 @@ public class MixinTileEntity implements ILPTEInformation {
 
     @Override
     public LPTileEntityObject getObject() {
-        return this.logisticspipes$informationObject;
+        return this.LogisticsPipes$informationObject;
     }
 
     @Override
     public void setObject(LPTileEntityObject object) {
-        this.logisticspipes$informationObject = object;
+        this.LogisticsPipes$informationObject = object;
     }
 }

--- a/src/main/java/logisticspipes/mixins/early/minecraft/MixinWorld.java
+++ b/src/main/java/logisticspipes/mixins/early/minecraft/MixinWorld.java
@@ -15,7 +15,7 @@ import logisticspipes.routing.pathfinder.changedetection.TEControl;
 public class MixinWorld {
 
     @Inject(at = @At("HEAD"), method = "notifyBlocksOfNeighborChange(IIILnet/minecraft/block/Block;)V")
-    private void logisticspipes$notifyBlocksOfNeighborChange_Start(int p_147459_1_, int p_147459_2_, int p_147459_3_,
+    private void LogisticsPipes$notifyBlocksOfNeighborChange_Start(int p_147459_1_, int p_147459_2_, int p_147459_3_,
             Block p_147459_4_, CallbackInfo ci) {
         try {
             TEControl.notifyBlocksOfNeighborChange_Start((World) (Object) this, p_147459_1_, p_147459_2_, p_147459_3_);
@@ -28,7 +28,7 @@ public class MixinWorld {
     }
 
     @Inject(at = @At("TAIL"), method = "notifyBlocksOfNeighborChange(IIILnet/minecraft/block/Block;)V")
-    private void logisticspipes$notifyBlocksOfNeighborChange_Stop(int p_147459_1_, int p_147459_2_, int p_147459_3_,
+    private void LogisticsPipes$notifyBlocksOfNeighborChange_Stop(int p_147459_1_, int p_147459_2_, int p_147459_3_,
             Block p_147459_4_, CallbackInfo ci) {
         try {
             TEControl.notifyBlocksOfNeighborChange_Stop((World) (Object) this, p_147459_1_, p_147459_2_, p_147459_3_);
@@ -41,7 +41,7 @@ public class MixinWorld {
     }
 
     @Inject(at = @At("HEAD"), method = "notifyBlockOfNeighborChange")
-    private void logisticspipes$notifyBlockOfNeighborChange(int p_147460_1_, int p_147460_2_, int p_147460_3_,
+    private void LogisticsPipes$notifyBlockOfNeighborChange(int p_147460_1_, int p_147460_2_, int p_147460_3_,
             final Block p_147460_4_, CallbackInfo ci) {
         try {
             TEControl.notifyBlockOfNeighborChange((World) (Object) this, p_147460_1_, p_147460_2_, p_147460_3_);

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinRenderDuctItems.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinRenderDuctItems.java
@@ -24,7 +24,7 @@ public class MixinRenderDuctItems {
                     value = "FIELD"),
             method = "renderTravelingItems",
             remap = false)
-    private void logisticspipes$renderItemTransportBox(CallbackInfo ci, @Local TravelingItem item) {
+    private void LogisticsPipes$renderItemTransportBox(CallbackInfo ci, @Local TravelingItem item) {
         if (!LogisticsRenderPipe.config.isUseNewRenderer()) {
             return;
         }

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinRenderDuctItems.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinRenderDuctItems.java
@@ -17,9 +17,10 @@ public class MixinRenderDuctItems {
 
     @Inject(
             at = @At(
-                    opcode = Opcodes.GETSTATIC,
+                    opcode = Opcodes.GETFIELD,
+                    ordinal = 1,
                     remap = false,
-                    target = "Lcofh/thermaldynamics/render/RenderDuctItems;travelingItemRender:Lnet/minecraft/client/renderer/entity/RenderItem;",
+                    target = "Lcofh/thermaldynamics/duct/item/TravelingItem;stack:Lnet/minecraft/item/ItemStack;",
                     value = "FIELD"),
             method = "renderTravelingItems",
             remap = false)

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinRenderDuctItems.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinRenderDuctItems.java
@@ -1,0 +1,36 @@
+package logisticspipes.mixins.late.thermaldynamics;
+
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import cofh.thermaldynamics.duct.item.TravelingItem;
+import cofh.thermaldynamics.render.RenderDuctItems;
+import logisticspipes.renderer.LogisticsRenderPipe;
+
+@Mixin(RenderDuctItems.class)
+public class MixinRenderDuctItems {
+
+    @Inject(
+            at = @At(
+                    opcode = Opcodes.GETSTATIC,
+                    remap = false,
+                    target = "Lcofh/thermaldynamics/render/RenderDuctItems;travelingItemRender:Lnet/minecraft/client/renderer/entity/RenderItem;",
+                    value = "FIELD"),
+            method = "renderTravelingItems",
+            remap = false)
+    private void logisticspipes$renderItemTransportBox(CallbackInfo ci, @Local TravelingItem item) {
+        if (!LogisticsRenderPipe.config.isUseNewRenderer()) {
+            return;
+        }
+        if (item.stack.hasTagCompound()) {
+            if (item.stack.getTagCompound().getString("LogsitcsPipes_ITEM_ON_TRANSPORTATION").equals("YES")) {
+                LogisticsRenderPipe.boxRenderer.doRenderItem(null, 0.0, 0.0, 0.0, 0.65 / 0.6);
+            }
+        }
+    }
+}

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTileTDBase.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTileTDBase.java
@@ -1,0 +1,44 @@
+package logisticspipes.mixins.late.thermaldynamics;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+import cofh.thermaldynamics.block.TileTDBase;
+import cofh.thermaldynamics.duct.Duct;
+import cofh.thermaldynamics.duct.item.TileItemDuct;
+import logisticspipes.asm.td.DuctAccessor;
+import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+
+@Mixin(TileTDBase.class)
+public class MixinTileTDBase implements DuctAccessor {
+
+    @Shadow(remap = false)
+    Duct duct;
+
+    @ModifyReturnValue(at = @At("RETURN"), method = "getAdjTileEntitySafe", remap = false)
+    private TileEntity logisticspipes$checkGetTileEntity(TileEntity tile, int side) {
+        if ((TileTDBase) (Object) this instanceof TileItemDuct) {
+            if (tile instanceof LogisticsTileGenericPipe) {
+                LogisticsTileGenericPipe pipe = (LogisticsTileGenericPipe) tile;
+                return pipe.tdPart.getInternalDuctForSide(ForgeDirection.getOrientation(side).getOpposite());
+            }
+        }
+        return tile;
+    }
+
+    @Override
+    public Duct getDuct() {
+        return this.duct;
+    }
+
+    @Override
+    public void setDuct(Duct duct) {
+        this.duct = duct;
+    }
+}

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTileTDBase.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTileTDBase.java
@@ -22,7 +22,7 @@ public class MixinTileTDBase implements DuctAccessor {
     Duct duct;
 
     @ModifyReturnValue(at = @At("RETURN"), method = "getAdjTileEntitySafe", remap = false)
-    private TileEntity logisticspipes$checkGetTileEntity(TileEntity tile, int side) {
+    private TileEntity LogisticsPipes$checkGetTileEntity(TileEntity tile, int side) {
         if ((TileTDBase) (Object) this instanceof TileItemDuct) {
             if (tile instanceof LogisticsTileGenericPipe) {
                 LogisticsTileGenericPipe pipe = (LogisticsTileGenericPipe) tile;

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTravelingItem.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTravelingItem.java
@@ -1,0 +1,74 @@
+package logisticspipes.mixins.late.thermaldynamics;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import cofh.thermaldynamics.duct.item.TravelingItem;
+import logisticspipes.asm.td.RoutingInformationAccessor;
+import logisticspipes.routing.ItemRoutingInformation;
+
+@Mixin(TravelingItem.class)
+public class MixinTravelingItem implements RoutingInformationAccessor {
+
+    @Unique
+    private ItemRoutingInformation logisticspipes$routingInformation;
+
+    @Override
+    public ItemRoutingInformation getRoutingInformation() {
+        return this.logisticspipes$routingInformation;
+    }
+
+    @Override
+    public void setRoutingInformation(ItemRoutingInformation routingInformation) {
+        this.logisticspipes$routingInformation = routingInformation;
+    }
+
+    @Inject(at = @At("HEAD"), method = "toNBT", remap = false)
+    private void logisticspipes$travelingItemToNBT(NBTTagCompound nbt, CallbackInfo ci) {
+        if (this.logisticspipes$routingInformation != null) {
+            NBTTagCompound save = new NBTTagCompound();
+            this.logisticspipes$routingInformation.writeToNBT(save);
+            nbt.setTag("LPRoutingInformation", save);
+        }
+    }
+
+    @Inject(at = @At("TAIL"), method = "<init>(Lnet/minecraft/nbt/NBTTagCompound;)V", remap = false)
+    private void logisticspipes$travelingItemNBTContructor(NBTTagCompound nbt, CallbackInfo ci) {
+        if (!nbt.hasKey("LPRoutingInformation")) {
+            return;
+        }
+        this.logisticspipes$routingInformation = new ItemRoutingInformation();
+        this.logisticspipes$routingInformation.readFromNBT(nbt.getCompoundTag("LPRoutingInformation"));
+    }
+
+    @ModifyExpressionValue(
+            at = @At(
+                    opcode = Opcodes.GETFIELD,
+                    remap = false,
+                    target = "Lcofh/thermaldynamics/duct/item/TravelingItem;stack:Lnet/minecraft/item/ItemStack;",
+                    value = "FIELD"),
+            method = "writePacket",
+            remap = false)
+    private ItemStack logisticspipes$handleItemSendPacket(ItemStack original) {
+        if (original == null) {
+            return null;
+        }
+        if (this.logisticspipes$routingInformation != null) {
+            original = original.copy();
+            if (!original.hasTagCompound()) {
+                original.setTagCompound(new NBTTagCompound());
+            }
+            original.getTagCompound().setString("LogsitcsPipes_ITEM_ON_TRANSPORTATION", "YES");
+        }
+        return original;
+    }
+}

--- a/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTravelingItem.java
+++ b/src/main/java/logisticspipes/mixins/late/thermaldynamics/MixinTravelingItem.java
@@ -20,34 +20,34 @@ import logisticspipes.routing.ItemRoutingInformation;
 public class MixinTravelingItem implements RoutingInformationAccessor {
 
     @Unique
-    private ItemRoutingInformation logisticspipes$routingInformation;
+    private ItemRoutingInformation LogisticsPipes$routingInformation;
 
     @Override
     public ItemRoutingInformation getRoutingInformation() {
-        return this.logisticspipes$routingInformation;
+        return this.LogisticsPipes$routingInformation;
     }
 
     @Override
     public void setRoutingInformation(ItemRoutingInformation routingInformation) {
-        this.logisticspipes$routingInformation = routingInformation;
+        this.LogisticsPipes$routingInformation = routingInformation;
     }
 
     @Inject(at = @At("HEAD"), method = "toNBT", remap = false)
-    private void logisticspipes$travelingItemToNBT(NBTTagCompound nbt, CallbackInfo ci) {
-        if (this.logisticspipes$routingInformation != null) {
+    private void LogisticsPipes$travelingItemToNBT(NBTTagCompound nbt, CallbackInfo ci) {
+        if (this.LogisticsPipes$routingInformation != null) {
             NBTTagCompound save = new NBTTagCompound();
-            this.logisticspipes$routingInformation.writeToNBT(save);
+            this.LogisticsPipes$routingInformation.writeToNBT(save);
             nbt.setTag("LPRoutingInformation", save);
         }
     }
 
     @Inject(at = @At("TAIL"), method = "<init>(Lnet/minecraft/nbt/NBTTagCompound;)V", remap = false)
-    private void logisticspipes$travelingItemNBTContructor(NBTTagCompound nbt, CallbackInfo ci) {
+    private void LogisticsPipes$travelingItemNBTContructor(NBTTagCompound nbt, CallbackInfo ci) {
         if (!nbt.hasKey("LPRoutingInformation")) {
             return;
         }
-        this.logisticspipes$routingInformation = new ItemRoutingInformation();
-        this.logisticspipes$routingInformation.readFromNBT(nbt.getCompoundTag("LPRoutingInformation"));
+        this.LogisticsPipes$routingInformation = new ItemRoutingInformation();
+        this.LogisticsPipes$routingInformation.readFromNBT(nbt.getCompoundTag("LPRoutingInformation"));
     }
 
     @ModifyExpressionValue(
@@ -58,11 +58,11 @@ public class MixinTravelingItem implements RoutingInformationAccessor {
                     value = "FIELD"),
             method = "writePacket",
             remap = false)
-    private ItemStack logisticspipes$handleItemSendPacket(ItemStack original) {
+    private ItemStack LogisticsPipes$handleItemSendPacket(ItemStack original) {
         if (original == null) {
             return null;
         }
-        if (this.logisticspipes$routingInformation != null) {
+        if (this.LogisticsPipes$routingInformation != null) {
             original = original.copy();
             if (!original.hasTagCompound()) {
                 original.setTagCompound(new NBTTagCompound());

--- a/src/main/java/logisticspipes/pipes/basic/LogisticsBlockGenericPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/LogisticsBlockGenericPipe.java
@@ -969,6 +969,7 @@ public class LogisticsBlockGenericPipe extends BlockContainer {
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         LogisticsNewRenderPipe.registerTextures(iconRegister);
+        SimpleServiceLocator.thermalDynamicsProxy.registerTextures(iconRegister);
         if (!skippedFirstIconRegister) {
             skippedFirstIconRegister = true;
             return;

--- a/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
@@ -1,6 +1,7 @@
 package logisticspipes.pipes.basic;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -72,6 +73,7 @@ import logisticspipes.proxy.buildcraft.subproxies.IConnectionOverrideResult;
 import logisticspipes.proxy.computers.wrapper.CCObjectWrapper;
 import logisticspipes.proxy.opencomputers.IOCTile;
 import logisticspipes.proxy.opencomputers.asm.BaseWrapperClass;
+import logisticspipes.proxy.td.subproxies.ITDPart;
 import logisticspipes.renderer.IIconProvider;
 import logisticspipes.renderer.LogisticsTileRenderController;
 import logisticspipes.renderer.state.PipeRenderState;
@@ -119,6 +121,7 @@ public class LogisticsTileGenericPipe extends TileEntity
     public final CoreState coreState = new CoreState();
     public final IBCTilePart tilePart;
     public final IBCPluggableState bcPlugableState;
+    public final ITDPart tdPart;
 
     @Getter
     private IBlockPos pos;
@@ -129,6 +132,7 @@ public class LogisticsTileGenericPipe extends TileEntity
         }
         SimpleServiceLocator.openComputersProxy.initLogisticsTileGenericPipe(this);
         tilePart = SimpleServiceLocator.buildCraftProxy.getBCTilePart(this);
+        tdPart = SimpleServiceLocator.thermalDynamicsProxy.getTDPart(this);
         renderState = new PipeRenderState(tilePart);
         bcPlugableState = tilePart.getBCPlugableState();
     }
@@ -153,6 +157,7 @@ public class LogisticsTileGenericPipe extends TileEntity
             super.invalidate();
             SimpleServiceLocator.openComputersProxy.handleInvalidate(this);
             tilePart.invalidate_LP();
+            tdPart.invalidate();
         }
     }
 
@@ -176,6 +181,7 @@ public class LogisticsTileGenericPipe extends TileEntity
             pipe.onChunkUnload();
         }
         SimpleServiceLocator.openComputersProxy.handleChunkUnload(this);
+        tdPart.onChunkUnload();
     }
 
     @Override
@@ -232,6 +238,7 @@ public class LogisticsTileGenericPipe extends TileEntity
             for (ForgeDirection o : ForgeDirection.VALID_DIRECTIONS) {
                 renderState.pipeConnectionMatrix.setConnected(o, pipeConnectionsBuffer[o.ordinal()]);
                 renderState.pipeConnectionMatrix.setBCConnected(o, pipeBCConnectionsBuffer[o.ordinal()]);
+                renderState.pipeConnectionMatrix.setTDConnected(o, pipeTDConnectionsBuffer[o.ordinal()]);
             }
             // Pipe Textures
             for (int i = 0; i < 7; i++) {
@@ -312,6 +319,7 @@ public class LogisticsTileGenericPipe extends TileEntity
     @Override
     public void scheduleNeighborChange() {
         tilePart.scheduleNeighborChange();
+        tdPart.scheduleNeighborChange();
         blockNeighborChange = true;
         boolean[] connected = new boolean[6];
         WorldUtil world = new WorldUtil(getWorld(), xCoord, yCoord, zCoord);
@@ -423,6 +431,9 @@ public class LogisticsTileGenericPipe extends TileEntity
         }
 
         if (!SimpleServiceLocator.buildCraftProxy.checkForPipeConnection(with, side, this)) {
+            return false;
+        }
+        if (SimpleServiceLocator.thermalDynamicsProxy.isBlockedSide(with, side.getOpposite())) {
             return false;
         }
         if (with instanceof LogisticsTileGenericPipe) {
@@ -692,6 +703,7 @@ public class LogisticsTileGenericPipe extends TileEntity
 
     public boolean[] pipeConnectionsBuffer = new boolean[6];
     public boolean[] pipeBCConnectionsBuffer = new boolean[6];
+    public boolean[] pipeTDConnectionsBuffer = new boolean[6];
 
     public CoreUnroutedPipe pipe;
     // public int redstoneInput = 0;
@@ -847,6 +859,8 @@ public class LogisticsTileGenericPipe extends TileEntity
             return;
         }
 
+        boolean[] pipeTDConnectionsBufferOld = pipeTDConnectionsBuffer.clone();
+
         for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
             TileBuffer t = cache[side.ordinal()];
             t.refresh();
@@ -855,9 +869,15 @@ public class LogisticsTileGenericPipe extends TileEntity
             if (pipeConnectionsBuffer[side.ordinal()]) {
                 pipeBCConnectionsBuffer[side.ordinal()] = SimpleServiceLocator.buildCraftProxy
                         .isTileGenericPipe(t.getTile());
+                pipeTDConnectionsBuffer[side.ordinal()] = SimpleServiceLocator.thermalDynamicsProxy
+                        .isItemDuct(t.getTile());
             } else {
                 pipeBCConnectionsBuffer[side.ordinal()] = false;
+                pipeTDConnectionsBuffer[side.ordinal()] = false;
             }
+        }
+        if (!Arrays.equals(pipeTDConnectionsBufferOld, pipeTDConnectionsBuffer)) {
+            tdPart.connectionsChanged();
         }
     }
 
@@ -1090,6 +1110,7 @@ public class LogisticsTileGenericPipe extends TileEntity
     public void setWorldObj(World world) {
         super.setWorldObj(world);
         tilePart.setWorldObj_LP(world);
+        tdPart.setWorldObj_LP(world);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/logisticspipes/proxy/ProxyManager.java
+++ b/src/main/java/logisticspipes/proxy/ProxyManager.java
@@ -12,6 +12,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -75,6 +76,7 @@ import logisticspipes.proxy.interfaces.IIC2Proxy;
 import logisticspipes.proxy.interfaces.IIronChestProxy;
 import logisticspipes.proxy.interfaces.INEIProxy;
 import logisticspipes.proxy.interfaces.IOpenComputersProxy;
+import logisticspipes.proxy.interfaces.ITDProxy;
 import logisticspipes.proxy.interfaces.IThaumCraftProxy;
 import logisticspipes.proxy.interfaces.IThermalExpansionProxy;
 import logisticspipes.proxy.interfaces.IToolWrenchProxy;
@@ -89,6 +91,8 @@ import logisticspipes.proxy.object3d.interfaces.IVec3;
 import logisticspipes.proxy.object3d.operation.LPScale;
 import logisticspipes.proxy.opencomputers.IOCTile;
 import logisticspipes.proxy.opencomputers.OpenComputersProxy;
+import logisticspipes.proxy.td.ThermalDynamicsProxy;
+import logisticspipes.proxy.td.subproxies.ITDPart;
 import logisticspipes.proxy.te.ThermalExpansionProxy;
 import logisticspipes.proxy.thaumcraft.ThaumCraftProxy;
 import logisticspipes.proxy.toolWrench.ToolWrenchProxy;
@@ -1013,6 +1017,63 @@ public class ProxyManager {
                 },
                 ICoFHEnergyReceiver.class,
                 ICoFHEnergyStorage.class));
+
+        SimpleServiceLocator.setThermalDynamicsProxy(ProxyManager.getWrappedProxy(
+                "ThermalDynamics",
+                ITDProxy.class,
+                ThermalDynamicsProxy.class,
+                new ITDProxy() {
+                    @Override
+                    public ITDPart getTDPart(final LogisticsTileGenericPipe pipe) {
+                        return new ITDPart() {
+                            @Override
+                            public TileEntity getInternalDuctForSide(ForgeDirection opposite) {
+                                return pipe;
+                            }
+
+                            @Override
+                            public void setWorldObj_LP(World world) {}
+
+                            @Override
+                            public void invalidate() {}
+
+                            @Override
+                            public void onChunkUnload() {}
+
+                            @Override
+                            public void scheduleNeighborChange() {}
+
+                            @Override
+                            public void connectionsChanged() {}
+                        };
+                    }
+
+                    @Override
+                    public boolean isActive() {
+                        return false;
+                    }
+
+                    @Override
+                    public void registerPipeInformationProvider() {}
+
+                    @Override
+                    public boolean isItemDuct(TileEntity tile) {
+                        return false;
+                    }
+
+                    @Override
+                    @SideOnly(Side.CLIENT)
+                    public void renderPipeConnections(LogisticsTileGenericPipe pipeTile, RenderBlocks renderer) {}
+
+                    @Override
+                    public void registerTextures(IIconRegister iconRegister) {}
+
+                    @Override
+                    public boolean isBlockedSide(TileEntity with, ForgeDirection opposite) {
+                        return false;
+                    }
+                },
+                ITDPart.class));
 
         SimpleServiceLocator.setBinnieProxy(
                 ProxyManager.getWrappedProxy("Genetics", IBinnieProxy.class, BinnieProxy.class, tile -> false));

--- a/src/main/java/logisticspipes/proxy/SimpleServiceLocator.java
+++ b/src/main/java/logisticspipes/proxy/SimpleServiceLocator.java
@@ -26,6 +26,7 @@ import logisticspipes.proxy.interfaces.IIC2Proxy;
 import logisticspipes.proxy.interfaces.IIronChestProxy;
 import logisticspipes.proxy.interfaces.INEIProxy;
 import logisticspipes.proxy.interfaces.IOpenComputersProxy;
+import logisticspipes.proxy.interfaces.ITDProxy;
 import logisticspipes.proxy.interfaces.IThaumCraftProxy;
 import logisticspipes.proxy.interfaces.IThermalExpansionProxy;
 import logisticspipes.proxy.interfaces.IToolWrenchProxy;
@@ -242,6 +243,12 @@ public final class SimpleServiceLocator {
 
     public static void setCoFHPowerProxy(ICoFHPowerProxy proxy) {
         SimpleServiceLocator.cofhPowerProxy = proxy;
+    }
+
+    public static ITDProxy thermalDynamicsProxy;
+
+    public static void setThermalDynamicsProxy(ITDProxy proxy) {
+        SimpleServiceLocator.thermalDynamicsProxy = proxy;
     }
 
     public static IBinnieProxy binnieProxy;

--- a/src/main/java/logisticspipes/proxy/buildcraft/BCLPPipeTransportItemsRenderer.java
+++ b/src/main/java/logisticspipes/proxy/buildcraft/BCLPPipeTransportItemsRenderer.java
@@ -17,7 +17,7 @@ public class BCLPPipeTransportItemsRenderer extends PipeTransportItemsRenderer {
                 if (LogisticsRenderPipe.boxRenderer != null) {
                     ItemIdentifierStack itemIdentifierStack = ItemIdentifierStack
                             .getFromStack(travellingItem.getItemStack());
-                    LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, x, y + 0.25, z);
+                    LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, x, y + 0.25, z, 1.0);
                 }
             }
         }

--- a/src/main/java/logisticspipes/proxy/interfaces/ITDProxy.java
+++ b/src/main/java/logisticspipes/proxy/interfaces/ITDProxy.java
@@ -1,0 +1,30 @@
+package logisticspipes.proxy.interfaces;
+
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+import logisticspipes.proxy.td.subproxies.ITDPart;
+
+public interface ITDProxy {
+
+    ITDPart getTDPart(LogisticsTileGenericPipe pipe);
+
+    boolean isActive();
+
+    void registerPipeInformationProvider();
+
+    boolean isItemDuct(TileEntity tile);
+
+    @SideOnly(Side.CLIENT)
+    void renderPipeConnections(LogisticsTileGenericPipe pipeTile, RenderBlocks renderer);
+
+    @SideOnly(Side.CLIENT)
+    void registerTextures(IIconRegister iconRegister);
+
+    boolean isBlockedSide(TileEntity with, ForgeDirection opposite);
+}

--- a/src/main/java/logisticspipes/proxy/td/LPItemDuct.java
+++ b/src/main/java/logisticspipes/proxy/td/LPItemDuct.java
@@ -1,0 +1,144 @@
+package logisticspipes.proxy.td;
+
+import java.util.ArrayList;
+import java.util.function.Supplier;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cofh.thermaldynamics.duct.Duct;
+import cofh.thermaldynamics.duct.TDDucts;
+import cofh.thermaldynamics.duct.item.TileItemDuct;
+import cofh.thermaldynamics.duct.item.TravelingItem;
+import cofh.thermaldynamics.multiblock.IMultiBlock;
+import logisticspipes.asm.td.DuctAccessor;
+import logisticspipes.logisticspipes.IRoutedItem.TransportMode;
+import logisticspipes.pipes.basic.CoreRoutedPipe;
+import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+import logisticspipes.proxy.SimpleServiceLocator;
+import logisticspipes.routing.ItemRoutingInformation;
+import logisticspipes.transport.LPTravelingItem.LPTravelingItemServer;
+import logisticspipes.utils.item.ItemIdentifier;
+import logisticspipes.utils.item.ItemIdentifierStack;
+import logisticspipes.utils.tuples.Pair;
+import logisticspipes.utils.tuples.Triplet;
+
+public class LPItemDuct extends TileItemDuct {
+
+    public final LogisticsTileGenericPipe pipe;
+    public final ForgeDirection dir;
+
+    public LPItemDuct(LogisticsTileGenericPipe pipe, ForgeDirection orientation) {
+        this.pipe = pipe;
+        dir = orientation;
+    }
+
+    @Override
+    public RouteInfo canRouteItem(ItemStack arg0) {
+        if (arg0 != null) {
+            if (pipe.pipe.isRoutedPipe() && !((CoreRoutedPipe) pipe.pipe).stillNeedReplace()) {
+                if (SimpleServiceLocator.logisticsManager.hasDestination(
+                        ItemIdentifier.get(arg0),
+                        true,
+                        ((CoreRoutedPipe) pipe.pipe).getRouterId(),
+                        new ArrayList<Integer>()) != null) {
+                    return new RouteInfo(0, (byte) dir.getOpposite().ordinal());
+                }
+            }
+        }
+        return TileItemDuct.noRoute;
+    }
+
+    @Override
+    public void transferItem(TravelingItem item) {
+        @SuppressWarnings("unchecked")
+        ItemRoutingInformation info = ((Supplier<ItemRoutingInformation>) item).get();
+        if (info != null) {
+            info.setItem(ItemIdentifierStack.getFromStack(item.stack));
+            LPTravelingItemServer lpItem = new LPTravelingItemServer(info);
+            lpItem.setSpeed(info._transportMode == TransportMode.Active ? 0.3F : 0.2F);
+            pipe.pipe.transport.injectItem(lpItem, ForgeDirection.getOrientation(item.direction));
+        } else if (item.stack != null) {
+            int consumed = pipe.injectItem(item.stack, true, dir);
+            item.stack.stackSize -= consumed;
+            if (item.stack.stackSize > 0) {
+                pipe.pipe.transport._itemBuffer.add(
+                        new Triplet<ItemIdentifierStack, Pair<Integer, Integer>, LPTravelingItemServer>(
+                                ItemIdentifierStack.getFromStack(item.stack),
+                                new Pair<Integer, Integer>(20 * 2, 0),
+                                null));
+            }
+        }
+    }
+
+    @Override
+    public boolean isBlockedSide(int paramInt) {
+        return isLPBlockedSide(paramInt, false);
+    }
+
+    public boolean isLPBlockedSide(int paramInt, boolean ignoreSystemDisconnect) {
+        ForgeDirection dir = ForgeDirection.getOrientation(paramInt);
+        if (pipe.tilePart.hasBlockingPluggable(dir)) {
+            return true;
+        }
+        if (pipe.pipe != null && pipe.pipe.isSideBlocked(dir, ignoreSystemDisconnect)) {
+            return false;
+        }
+        return super.isBlockedSide(paramInt);
+    }
+
+    @Override
+    public Duct getDuctType() {
+        if (((DuctAccessor) this).getDuct() == null) {
+            ((DuctAccessor) this).setDuct(TDDucts.itemBasic);
+        }
+        return ((DuctAccessor) this).getDuct();
+    }
+
+    @Override
+    public void handleSideUpdate(int paramInt) {
+        super.handleSideUpdate(paramInt);
+        isOutput = true;
+    }
+
+    @Override
+    public IMultiBlock getConnectedSide(byte paramByte) {
+        if (ForgeDirection.getOrientation(paramByte) != dir) {
+            return null;
+        }
+        return super.getConnectedSide(paramByte);
+    }
+
+    @Override
+    public NeighborTypes getCachedSideType(byte paramByte) {
+        if (ForgeDirection.getOrientation(paramByte) != dir) {
+            return null;
+        }
+        return super.getCachedSideType(paramByte);
+    }
+
+    @Override
+    public ConnectionTypes getConnectionType(byte paramByte) {
+        if (ForgeDirection.getOrientation(paramByte) != dir) {
+            return null;
+        }
+        return super.getConnectionType(paramByte);
+    }
+
+    @Override
+    public IMultiBlock getCachedTile(byte paramByte) {
+        if (ForgeDirection.getOrientation(paramByte) != dir) {
+            return null;
+        }
+        return super.getCachedTile(paramByte);
+    }
+
+    @Override
+    public TileEntity getAdjTileEntitySafe(int ordinal) {
+        if (ForgeDirection.getOrientation(ordinal) != dir) {
+            return null;
+        }
+        return super.getAdjTileEntitySafe(ordinal);
+    }
+}

--- a/src/main/java/logisticspipes/proxy/td/LPItemDuct.java
+++ b/src/main/java/logisticspipes/proxy/td/LPItemDuct.java
@@ -1,7 +1,6 @@
 package logisticspipes.proxy.td;
 
 import java.util.ArrayList;
-import java.util.function.Supplier;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -13,6 +12,7 @@ import cofh.thermaldynamics.duct.item.TileItemDuct;
 import cofh.thermaldynamics.duct.item.TravelingItem;
 import cofh.thermaldynamics.multiblock.IMultiBlock;
 import logisticspipes.asm.td.DuctAccessor;
+import logisticspipes.asm.td.RoutingInformationAccessor;
 import logisticspipes.logisticspipes.IRoutedItem.TransportMode;
 import logisticspipes.pipes.basic.CoreRoutedPipe;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
@@ -52,8 +52,7 @@ public class LPItemDuct extends TileItemDuct {
 
     @Override
     public void transferItem(TravelingItem item) {
-        @SuppressWarnings("unchecked")
-        ItemRoutingInformation info = ((Supplier<ItemRoutingInformation>) item).get();
+        ItemRoutingInformation info = ((RoutingInformationAccessor) item).getRoutingInformation();
         if (info != null) {
             info.setItem(ItemIdentifierStack.getFromStack(item.stack));
             LPTravelingItemServer lpItem = new LPTravelingItemServer(info);

--- a/src/main/java/logisticspipes/proxy/td/TDDuctInformationProvider.java
+++ b/src/main/java/logisticspipes/proxy/td/TDDuctInformationProvider.java
@@ -1,0 +1,325 @@
+package logisticspipes.proxy.td;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cofh.lib.util.helpers.BlockHelper;
+import cofh.thermaldynamics.block.TileTDBase;
+import cofh.thermaldynamics.duct.item.TileItemDuct;
+import cofh.thermaldynamics.duct.item.TravelingItem;
+import cofh.thermaldynamics.multiblock.Route;
+import cofh.thermaldynamics.multiblock.RouteCache;
+import logisticspipes.asm.td.RoutingInformationAccessor;
+import logisticspipes.asm.te.ILPTEInformation;
+import logisticspipes.interfaces.routing.IFilter;
+import logisticspipes.logisticspipes.IRoutedItem.TransportMode;
+import logisticspipes.pipes.basic.CoreRoutedPipe;
+import logisticspipes.proxy.SimpleServiceLocator;
+import logisticspipes.routing.IRouter;
+import logisticspipes.routing.pathfinder.IPipeInformationProvider;
+import logisticspipes.routing.pathfinder.IRouteProvider;
+import logisticspipes.transport.LPTravelingItem;
+import logisticspipes.transport.LPTravelingItem.LPTravelingItemServer;
+import logisticspipes.utils.CacheHolder.CacheTypes;
+import logisticspipes.utils.item.ItemIdentifier;
+import logisticspipes.utils.tuples.LPPosition;
+import logisticspipes.utils.tuples.Pair;
+import logisticspipes.utils.tuples.Triplet;
+
+public class TDDuctInformationProvider implements IPipeInformationProvider, IRouteProvider {
+
+    private final TileItemDuct duct;
+
+    public TDDuctInformationProvider(TileItemDuct duct) {
+        this.duct = duct;
+    }
+
+    @Override
+    public boolean isCorrect() {
+        return duct != null && !duct.isInvalid() && SimpleServiceLocator.thermalDynamicsProxy.isActive();
+    }
+
+    @Override
+    public int getX() {
+        return duct.xCoord;
+    }
+
+    @Override
+    public int getY() {
+        return duct.yCoord;
+    }
+
+    @Override
+    public int getZ() {
+        return duct.zCoord;
+    }
+
+    @Override
+    public World getWorld() {
+        return duct.getWorldObj();
+    }
+
+    @Override
+    public boolean isRouterInitialized() {
+        return !duct.isInvalid();
+    }
+
+    @Override
+    public boolean isRoutingPipe() {
+        return false;
+    }
+
+    @Override
+    public CoreRoutedPipe getRoutingPipe() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TileEntity getTile(ForgeDirection direction) {
+        return BlockHelper.getAdjacentTileEntity(duct, direction);
+    }
+
+    @Override
+    public boolean isFirewallPipe() {
+        return false;
+    }
+
+    @Override
+    public IFilter getFirewallFilter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TileEntity getTile() {
+        return duct;
+    }
+
+    @Override
+    public boolean divideNetwork() {
+        return false;
+    }
+
+    @Override
+    public boolean powerOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isOnewayPipe() {
+        return false;
+    }
+
+    @Override
+    public boolean isOutputOpen(ForgeDirection direction) {
+        return duct.isSideConnected((byte) direction.ordinal());
+    }
+
+    @Override
+    public boolean canConnect(TileEntity to, ForgeDirection direction, boolean ignoreSystemDisconnect) {
+        TileEntity connection = duct.getAdjTileEntitySafe(direction.ordinal());
+        if (!(connection instanceof TileTDBase)) {
+            return false;
+        }
+        if (duct.isBlockedSide(direction.ordinal())) {
+            return false;
+        }
+        if (connection instanceof LPItemDuct) {
+            return !((LPItemDuct) connection)
+                    .isLPBlockedSide(direction.getOpposite().ordinal(), ignoreSystemDisconnect);
+        } else {
+            return !((TileTDBase) connection).isBlockedSide(direction.getOpposite().ordinal());
+        }
+    }
+
+    @Override
+    public double getDistance() {
+        return Math.max(duct.getDuctType().pathWeight, 0);
+    }
+
+    @Override
+    public boolean isItemPipe() {
+        return true;
+    }
+
+    @Override
+    public boolean isFluidPipe() {
+        return false;
+    }
+
+    @Override
+    public boolean isPowerPipe() {
+        return false;
+    }
+
+    @Override
+    public double getDistanceTo(int destinationint, ForgeDirection ignore, ItemIdentifier ident, boolean isActive,
+            double traveled, double max, List<LPPosition> visited) {
+        if (traveled >= max) {
+            return Integer.MAX_VALUE;
+        }
+        IRouter destination = SimpleServiceLocator.routerManager.getRouter(destinationint);
+        if (destination == null) {
+            return Integer.MAX_VALUE;
+        }
+        Iterable<Route> paramIterable = duct.getCache(true).outputRoutes;
+        double closesedConnection = Integer.MAX_VALUE;
+        for (Route localRoute1 : paramIterable) {
+            if (localRoute1.endPoint instanceof LPItemDuct) {
+                LPItemDuct lpDuct = (LPItemDuct) localRoute1.endPoint;
+
+                if (traveled + localRoute1.pathWeight > max) {
+                    continue;
+                }
+
+                LPPosition pos = new LPPosition((TileEntity) lpDuct.pipe);
+                if (visited.contains(pos)) {
+                    continue;
+                }
+                visited.add(pos);
+
+                double distance = lpDuct.pipe.getDistanceTo(
+                        destinationint,
+                        ForgeDirection
+                                .getOrientation(localRoute1.pathDirections.get(localRoute1.pathDirections.size() - 1))
+                                .getOpposite(),
+                        ident,
+                        isActive,
+                        traveled + localRoute1.pathWeight,
+                        Math.min(max, closesedConnection),
+                        visited);
+
+                visited.remove(pos);
+
+                if (distance != Integer.MAX_VALUE && distance + localRoute1.pathWeight < closesedConnection) {
+                    closesedConnection = distance + localRoute1.pathWeight;
+                }
+            }
+        }
+        return closesedConnection;
+    }
+
+    @Override
+    public boolean acceptItem(LPTravelingItem item, TileEntity from) {
+        if (item instanceof LPTravelingItemServer) {
+            LPTravelingItemServer serverItem = (LPTravelingItemServer) item;
+            int id = serverItem.getInfo().destinationint;
+            if (id == -1) {
+                id = SimpleServiceLocator.routerManager.getIDforUUID(serverItem.getInfo().destinationUUID);
+            }
+            IRouter destination = SimpleServiceLocator.routerManager.getRouter(id);
+            if (destination == null) {
+                return false;
+            }
+            RouteCache routes = duct.getCache(true);
+            Iterable<Route> paramIterable = routes.outputRoutes;
+            Route route = null;
+            Object cache = null;
+            Triplet<Integer, ItemIdentifier, Boolean> key = new Triplet<Integer, ItemIdentifier, Boolean>(
+                    id,
+                    item.getItemIdentifierStack().getItem(),
+                    serverItem.getInfo()._transportMode == TransportMode.Active);
+            if (duct instanceof ILPTEInformation && ((ILPTEInformation) duct).getObject() != null) {
+                cache = ((ILPTEInformation) duct).getObject().getCacheHolder().getCacheFor(CacheTypes.Routing, key);
+            }
+            if (cache instanceof Route) {
+                route = (Route) cache;
+                if (!routes.outputRoutes.contains(route)) {
+                    route = null;
+                }
+            }
+            if (route == null) {
+                Pair<Double, Route> closesedConnection = null;
+                List<LPPosition> visited = new ArrayList<LPPosition>();
+                visited.add(new LPPosition(from));
+                for (Route localRoute1 : paramIterable) {
+                    if (localRoute1.endPoint instanceof LPItemDuct) {
+                        LPItemDuct lpDuct = (LPItemDuct) localRoute1.endPoint;
+
+                        double max = Integer.MAX_VALUE;
+                        if (closesedConnection != null) {
+                            max = closesedConnection.getValue1();
+                        }
+
+                        LPPosition pos = new LPPosition((TileEntity) lpDuct.pipe);
+                        if (visited.contains(pos)) {
+                            continue;
+                        }
+                        visited.add(pos);
+
+                        double distance = lpDuct.pipe.getDistanceTo(
+                                id,
+                                ForgeDirection
+                                        .getOrientation(
+                                                localRoute1.pathDirections.get(localRoute1.pathDirections.size() - 1))
+                                        .getOpposite(),
+                                item.getItemIdentifierStack().getItem(),
+                                serverItem.getInfo()._transportMode == TransportMode.Active,
+                                localRoute1.pathWeight,
+                                max,
+                                visited);
+
+                        visited.remove(pos);
+
+                        if (distance != Integer.MAX_VALUE && (closesedConnection == null
+                                || distance + localRoute1.pathDirections.size() < closesedConnection.getValue1())) {
+                            closesedConnection = new Pair<Double, Route>(
+                                    distance + localRoute1.pathWeight,
+                                    localRoute1);
+                        }
+                    }
+                }
+                if (closesedConnection != null) {
+                    route = closesedConnection.getValue2();
+                }
+            }
+            if (route != null) {
+                if (duct instanceof ILPTEInformation && ((ILPTEInformation) duct).getObject() != null) {
+                    ((ILPTEInformation) duct).getObject().getCacheHolder().setCache(CacheTypes.Routing, key, route);
+                }
+                TravelingItem travelItem = new TravelingItem(
+                        item.getItemIdentifierStack().makeNormalStack(),
+                        duct,
+                        route.copy(),
+                        (byte) serverItem.output.ordinal(),
+                        (byte) 1 /* Speed */);
+                ((RoutingInformationAccessor) travelItem).setRoutingInformation(serverItem.getInfo());
+                duct.insertNewItem(travelItem);
+                return true;
+            }
+        } else {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void refreshTileCacheOnSide(ForgeDirection side) {
+        if (duct.myGrid == null) return;
+        duct.myGrid.destroyAndRecreate();
+    }
+
+    @Override
+    public List<RouteInfo> getConnectedPipes(ForgeDirection from) {
+        List<RouteInfo> list = new ArrayList<RouteInfo>();
+        if (duct.internalGrid == null) {
+            return null;
+        }
+        Iterable<Route> paramIterable = duct.getCache(true).outputRoutes;
+        for (Route localRoute1 : paramIterable) {
+            if (localRoute1.endPoint instanceof LPItemDuct) {
+                LPItemDuct lpDuct = (LPItemDuct) localRoute1.endPoint;
+                list.add(
+                        new RouteInfo(
+                                lpDuct.pipe,
+                                localRoute1.pathWeight,
+                                ForgeDirection.getOrientation(
+                                        localRoute1.pathDirections.get(localRoute1.pathDirections.size() - 1))));
+            }
+        }
+        return list;
+    }
+}

--- a/src/main/java/logisticspipes/proxy/td/ThermalDynamicsProxy.java
+++ b/src/main/java/logisticspipes/proxy/td/ThermalDynamicsProxy.java
@@ -1,0 +1,98 @@
+package logisticspipes.proxy.td;
+
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cofh.repack.codechicken.lib.render.CCRenderState;
+import cofh.repack.codechicken.lib.render.uv.IconTransformation;
+import cofh.repack.codechicken.lib.vec.Translation;
+import cofh.thermaldynamics.duct.item.TileItemDuct;
+import cofh.thermaldynamics.render.RenderDuct;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+import logisticspipes.proxy.SimpleServiceLocator;
+import logisticspipes.proxy.interfaces.ITDProxy;
+import logisticspipes.proxy.td.subproxies.ITDPart;
+import logisticspipes.proxy.td.subproxies.TDPart;
+
+public class ThermalDynamicsProxy implements ITDProxy {
+
+    private IconTransformation connectionTextureBasic;
+    private IconTransformation connectionTextureActive;
+    private IconTransformation connectionTextureInactive;
+
+    @Override
+    public void registerPipeInformationProvider() {
+        SimpleServiceLocator.pipeInformationManager
+                .registerProvider(TileItemDuct.class, TDDuctInformationProvider.class);
+    }
+
+    @Override
+    public ITDPart getTDPart(LogisticsTileGenericPipe pipe) {
+        return new TDPart(pipe);
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public boolean isItemDuct(TileEntity tile) {
+        return tile instanceof TileItemDuct;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void renderPipeConnections(LogisticsTileGenericPipe pipeTile, RenderBlocks renderer) {
+        for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+            if (pipeTile.renderState.pipeConnectionMatrix.isTDConnected(dir)) {
+                IconTransformation texture = connectionTextureBasic;
+                if (pipeTile.renderState.textureMatrix.isRouted()) {
+                    if (pipeTile.renderState.textureMatrix.isRoutedInDir(dir)) {
+                        texture = connectionTextureActive;
+                    } else {
+                        texture = connectionTextureInactive;
+                    }
+                }
+                double move = 0.25;
+                Translation localTranslation = new Translation(
+                        pipeTile.xCoord + 0.5D + dir.offsetX * move,
+                        pipeTile.yCoord + 0.5D + dir.offsetY * move,
+                        pipeTile.zCoord + 0.5D + dir.offsetZ * move);
+                RenderDuct.modelConnection[2][dir.ordinal()]
+                        .render(new CCRenderState.IVertexOperation[] { localTranslation, texture });
+            }
+        }
+    }
+
+    @Override
+    public void registerTextures(IIconRegister iconRegister) {
+        if (connectionTextureBasic == null) {
+            connectionTextureBasic = new IconTransformation(
+                    iconRegister.registerIcon("logisticspipes:" + "pipes/ThermalDynamicsConnection-Basic"));
+            connectionTextureActive = new IconTransformation(
+                    iconRegister.registerIcon("logisticspipes:" + "pipes/ThermalDynamicsConnection-Active"));
+            connectionTextureInactive = new IconTransformation(
+                    iconRegister.registerIcon("logisticspipes:" + "pipes/ThermalDynamicsConnection-Inactive"));
+        } else {
+            connectionTextureBasic.icon = iconRegister
+                    .registerIcon("logisticspipes:" + "pipes/ThermalDynamicsConnection-Basic");
+            connectionTextureActive.icon = iconRegister
+                    .registerIcon("logisticspipes:" + "pipes/ThermalDynamicsConnection-Active");
+            connectionTextureInactive.icon = iconRegister
+                    .registerIcon("logisticspipes:" + "pipes/ThermalDynamicsConnection-Inactive");
+        }
+    }
+
+    @Override
+    public boolean isBlockedSide(TileEntity with, ForgeDirection opposite) {
+        if (!(with instanceof TileItemDuct)) {
+            return false;
+        }
+        return ((TileItemDuct) with).isBlockedSide(opposite.ordinal());
+    }
+}

--- a/src/main/java/logisticspipes/proxy/td/subproxies/ITDPart.java
+++ b/src/main/java/logisticspipes/proxy/td/subproxies/ITDPart.java
@@ -1,0 +1,20 @@
+package logisticspipes.proxy.td.subproxies;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface ITDPart {
+
+    TileEntity getInternalDuctForSide(ForgeDirection opposite);
+
+    void setWorldObj_LP(World world);
+
+    void invalidate();
+
+    void onChunkUnload();
+
+    void scheduleNeighborChange();
+
+    void connectionsChanged();
+}

--- a/src/main/java/logisticspipes/proxy/td/subproxies/TDPart.java
+++ b/src/main/java/logisticspipes/proxy/td/subproxies/TDPart.java
@@ -1,0 +1,93 @@
+package logisticspipes.proxy.td.subproxies;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import cofh.thermaldynamics.core.TickHandler;
+import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+import logisticspipes.proxy.MainProxy;
+import logisticspipes.proxy.td.LPItemDuct;
+import logisticspipes.utils.tuples.LPPosition;
+
+public class TDPart implements ITDPart {
+
+    private final LogisticsTileGenericPipe pipe;
+    private final LPItemDuct[] thermalDynamicsDucts;
+
+    public TDPart(LogisticsTileGenericPipe pipe) {
+        this.pipe = pipe;
+        thermalDynamicsDucts = new LPItemDuct[6];
+    }
+
+    @Override
+    public TileEntity getInternalDuctForSide(ForgeDirection opposite) {
+        if (opposite.ordinal() < 6) {
+            LPItemDuct duct = thermalDynamicsDucts[opposite.ordinal()];
+            if (duct == null) {
+                duct = thermalDynamicsDucts[opposite.ordinal()] = new LPItemDuct(pipe, opposite);
+                if (MainProxy.isServer(pipe.getWorldObj())) {
+                    TickHandler.addMultiBlockToCalculate(duct);
+                }
+                duct.setWorldObj(pipe.getWorldObj());
+                duct.xCoord = pipe.xCoord;
+                duct.yCoord = pipe.yCoord;
+                duct.zCoord = pipe.zCoord;
+                duct.validate();
+                LPPosition pos = new LPPosition((TileEntity) pipe);
+                pos.moveForward(opposite);
+                duct.onNeighborTileChange(pos.getX(), pos.getY(), pos.getZ());
+            }
+            return duct;
+        }
+        return null;
+    }
+
+    @Override
+    public void setWorldObj_LP(World world) {
+        for (int i = 0; i < 6; i++) {
+            if (thermalDynamicsDucts[i] != null) {
+                thermalDynamicsDucts[i].setWorldObj(world);
+                thermalDynamicsDucts[i].xCoord = pipe.xCoord;
+                thermalDynamicsDucts[i].yCoord = pipe.yCoord;
+                thermalDynamicsDucts[i].zCoord = pipe.zCoord;
+            }
+        }
+    }
+
+    @Override
+    public void invalidate() {
+        for (int i = 0; i < 6; i++) {
+            if (thermalDynamicsDucts[i] != null) {
+                thermalDynamicsDucts[i].invalidate();
+            }
+        }
+    }
+
+    @Override
+    public void onChunkUnload() {
+        for (int i = 0; i < 6; i++) {
+            if (thermalDynamicsDucts[i] != null) {
+                thermalDynamicsDucts[i].onChunkUnload();
+            }
+        }
+    }
+
+    @Override
+    public void scheduleNeighborChange() {
+        for (int i = 0; i < 6; i++) {
+            if (thermalDynamicsDucts[i] != null) {
+                thermalDynamicsDucts[i].onNeighborBlockChange();
+            }
+        }
+    }
+
+    @Override
+    public void connectionsChanged() {
+        for (int i = 0; i < 6; i++) {
+            if (thermalDynamicsDucts[i] != null && thermalDynamicsDucts[i].myGrid != null) {
+                thermalDynamicsDucts[i].myGrid.destroyAndRecreate();
+            }
+        }
+    }
+}

--- a/src/main/java/logisticspipes/renderer/LogisticsPipeWorldRenderer.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsPipeWorldRenderer.java
@@ -14,6 +14,7 @@ import logisticspipes.config.PlayerConfig;
 import logisticspipes.pipes.PipeBlockRequestTable;
 import logisticspipes.pipes.basic.LogisticsBlockGenericPipe;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
+import logisticspipes.proxy.SimpleServiceLocator;
 import logisticspipes.proxy.buildcraft.subproxies.IBCPipePluggable;
 import logisticspipes.renderer.newpipe.LogisticsNewPipeWorldRenderer;
 import logisticspipes.renderer.state.PipeRenderState;
@@ -210,6 +211,7 @@ public class LogisticsPipeWorldRenderer implements ISimpleBlockRenderingHandler 
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile == null) return false;
         LogisticsTileGenericPipe pipeTile = (LogisticsTileGenericPipe) tile;
+        SimpleServiceLocator.thermalDynamicsProxy.renderPipeConnections(pipeTile, renderer);
         if (config.isUseNewRenderer() && !pipeTile.renderState.forceRenderOldPipe) {
             return newRenderer.renderWorldBlock(world, x, y, z, block, modelId, renderer);
         }

--- a/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/LogisticsRenderPipe.java
@@ -152,6 +152,7 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
 
             pos.reset(0.5D, 0.5D, 0.5D);
             float fPos = item.getPosition() + item.getSpeed() * partialTickTime;
+            double boxScale = 1;
 
             if (fPos < 0.5) {
                 if (item.input == ForgeDirection.UNKNOWN) {
@@ -170,6 +171,16 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                 }
                 pos.moveForward(item.output, fPos - 0.5F);
             }
+            if (pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.input.getOpposite())) {
+                boxScale = (fPos * (1 - 0.65)) + 0.65;
+            }
+            if (pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.output)) {
+                boxScale = ((1 - fPos) * (1 - 0.65)) + 0.65;
+            }
+            if (pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.input.getOpposite())
+                    && pipe.container.renderState.pipeConnectionMatrix.isTDConnected(item.output)) {
+                boxScale = 0.65;
+            }
 
             doRenderItem(
                     item.getItemIdentifierStack(),
@@ -178,7 +189,7 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                     y + pos.getYD(),
                     z + pos.getZD(),
                     0.75F,
-                    /* renderTransportBox */ true,
+                    boxScale,
                     partialTickTime);
             count++;
         }
@@ -196,7 +207,7 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
                     y + pos.getYD(),
                     z + pos.getZD(),
                     0.25F,
-                    /* renderTransportBox */ false,
+                    0.0,
                     partialTickTime);
             count++;
             if (count >= 27) {
@@ -217,9 +228,9 @@ public class LogisticsRenderPipe extends TileEntitySpecialRenderer {
     }
 
     public void doRenderItem(ItemIdentifierStack itemIdentifierStack, World worldObj, double x, double y, double z,
-            float renderScale, boolean renderTransportBox, float partialTickTime) {
-        if (LogisticsRenderPipe.config.isUseNewRenderer() && renderTransportBox) {
-            LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, x, y, z);
+            float renderScale, double boxScale, float partialTickTime) {
+        if (LogisticsRenderPipe.config.isUseNewRenderer() && boxScale != 0.0) {
+            LogisticsRenderPipe.boxRenderer.doRenderItem(itemIdentifierStack, x, y, z, boxScale);
         }
 
         GL11.glPushMatrix();

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewPipeItemBoxRenderer.java
@@ -36,7 +36,7 @@ public class LogisticsNewPipeItemBoxRenderer {
     private static final ResourceLocation BLOCKS = new ResourceLocation("textures/atlas/blocks.png");
     private static final Map<FluidIdentifier, int[]> renderLists = new HashMap<>();
 
-    public void doRenderItem(ItemIdentifierStack itemIdentifierStack, double x, double y, double z) {
+    public void doRenderItem(ItemIdentifierStack itemIdentifierStack, double x, double y, double z, double boxScale) {
         if (LogisticsNewRenderPipe.innerTransportBox == null) return;
         GL11.glPushMatrix();
 
@@ -45,14 +45,20 @@ public class LogisticsNewPipeItemBoxRenderer {
             else renderList = generateInnerBoxDisplayList();
         }
 
+        GL11.glTranslated(x, y, z);
         Minecraft.getMinecraft().getTextureManager().bindTexture(LogisticsNewPipeItemBoxRenderer.BLOCKS);
-        GL11.glTranslated(x - 0.5, y - 0.5, z - 0.5);
+        GL11.glScaled(boxScale, boxScale, boxScale);
+        GL11.glTranslated(-0.5, -0.5, -0.5);
 
         if (LogisticsPipes.enableVBO) {
             VBOManager.get(renderList).render();
         } else {
             GL11.glCallList(renderList);
         }
+
+        GL11.glTranslated(0.5, 0.5, 0.5);
+        GL11.glScaled(1 / boxScale, 1 / boxScale, 1 / boxScale);
+        GL11.glTranslated(-0.5, -0.5, -0.5);
 
         if (itemIdentifierStack != null && itemIdentifierStack.getItem().item instanceof LogisticsFluidContainer) {
             FluidStack f = SimpleServiceLocator.logisticsFluidManager.getFluidFromContainer(itemIdentifierStack);

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
@@ -804,7 +804,8 @@ public class LogisticsNewRenderPipe {
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
             if (renderState.pipeConnectionMatrix.isConnected(dir)) {
                 connectionCount++;
-                if (renderState.pipeConnectionMatrix.isBCConnected(dir)) {
+                if (renderState.pipeConnectionMatrix.isBCConnected(dir)
+                        || renderState.pipeConnectionMatrix.isTDConnected(dir)) {
                     I3DOperation[] texture = new I3DOperation[] { LogisticsNewRenderPipe.basicTexture };
                     if (renderState.textureMatrix.isRouted()) {
                         if (renderState.textureMatrix.isRoutedInDir(dir)) {

--- a/src/main/java/logisticspipes/renderer/state/ConnectionMatrix.java
+++ b/src/main/java/logisticspipes/renderer/state/ConnectionMatrix.java
@@ -11,6 +11,7 @@ public class ConnectionMatrix {
 
     private int mask = 0;
     private int isBCPipeMask = 0;
+    private int isTDPipeMask = 0;
     private boolean dirty = false;
 
     public boolean isConnected(ForgeDirection direction) {
@@ -26,6 +27,7 @@ public class ConnectionMatrix {
         }
         if (!value) {
             setBCConnected(direction, false);
+            setTDConnected(direction, false);
         }
     }
 
@@ -38,6 +40,19 @@ public class ConnectionMatrix {
         if (isBCConnected(direction) != value) {
             // invert the direction.ordinal()'th bit of mask
             isBCPipeMask ^= 1 << direction.ordinal();
+            dirty = true;
+        }
+    }
+
+    public boolean isTDConnected(ForgeDirection direction) {
+        // test if the direction.ordinal()'th bit of mask is set
+        return (isTDPipeMask & (1 << direction.ordinal())) != 0;
+    }
+
+    public void setTDConnected(ForgeDirection direction, boolean value) {
+        if (isTDConnected(direction) != value) {
+            // invert the direction.ordinal()'th bit of mask
+            isTDPipeMask ^= 1 << direction.ordinal();
             dirty = true;
         }
     }
@@ -62,6 +77,7 @@ public class ConnectionMatrix {
     public void writeData(LPDataOutputStream data) throws IOException {
         data.writeByte(mask);
         data.writeByte(isBCPipeMask);
+        data.writeByte(isTDPipeMask);
     }
 
     public void readData(LPDataInputStream data) throws IOException {
@@ -75,6 +91,12 @@ public class ConnectionMatrix {
         newMask = data.readByte();
         if (newMask != isBCPipeMask) {
             isBCPipeMask = newMask;
+            dirty = true;
+        }
+
+        newMask = data.readByte();
+        if (newMask != isTDPipeMask) {
+            isTDPipeMask = newMask;
             dirty = true;
         }
     }


### PR DESCRIPTION
Partially reverts https://github.com/GTNewHorizons/LogisticsPipes/pull/11 and https://github.com/GTNewHorizons/LogisticsPipes/pull/52.

This PR adds back all Thermal Dynamics compat, without using any ASM. While we don't use Thermal Dynamics in GTNH, other packs do. By using Mixins, the effort to find and fix bugs should be much lower. The compile stubs aren't needed either.

**NOTE: Review #90 first, then this PR. Merge this PR first, then #90.**