### PR TITLE
Fix wrong type of Collection being casted to

### DIFF
--- a/src/main/java/logisticspipes/utils/gui/DummyContainer.java
+++ b/src/main/java/logisticspipes/utils/gui/DummyContainer.java
@@ -37,7 +37,6 @@ import logisticspipes.proxy.MainProxy;
 import logisticspipes.request.resources.DictResource;
 import logisticspipes.utils.FluidIdentifier;
 import logisticspipes.utils.MinecraftColor;
-import logisticspipes.utils.PlayerCollectionList;
 import logisticspipes.utils.item.ItemIdentifier;
 
 public class DummyContainer extends Container {
@@ -869,6 +868,7 @@ public class DummyContainer extends Container {
         super.putStackInSlot(par1, par2ItemStack);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void detectAndSendChanges() {
         for (int i = 0; i < inventorySlots.size(); ++i) {
@@ -880,7 +880,7 @@ public class DummyContainer extends Container {
                     MainProxy.sendToPlayerList(
                             PacketHandler.getPacket(FuzzySlotSettingsPacket.class).setSlotNumber(fuzzySlot.getSlotId())
                                     .setFlags(set),
-                            (PlayerCollectionList) crafters);
+                            (Iterable<EntityPlayer>) (Object) crafters);
                     inventoryFuzzySlotsContent.set(i, set);
                 } else {
                     BitSet setB = fuzzySlot.getFuzzyFlags().getBitSet();
@@ -888,7 +888,7 @@ public class DummyContainer extends Container {
                         MainProxy.sendToPlayerList(
                                 PacketHandler.getPacket(FuzzySlotSettingsPacket.class)
                                         .setSlotNumber(fuzzySlot.getSlotId()).setFlags(setB),
-                                (PlayerCollectionList) crafters);
+                                (Iterable<EntityPlayer>) (Object) crafters);
                         inventoryFuzzySlotsContent.set(i, setB);
                     }
                 }
@@ -900,14 +900,14 @@ public class DummyContainer extends Container {
                 itemstack1 = itemstack == null ? null : itemstack.copy();
                 inventoryItemStacks.set(i, itemstack1);
 
-                for (Object crafter : crafters) {
+                for (ICrafting crafter : crafters) {
                     boolean revert = false;
-                    if (overrideMCAntiSend && crafter instanceof EntityPlayerMP
-                            && ((EntityPlayerMP) crafter).isChangingQuantityOnly) {
-                        ((EntityPlayerMP) crafter).isChangingQuantityOnly = false;
+                    if (overrideMCAntiSend && crafter instanceof EntityPlayerMP player
+                            && player.isChangingQuantityOnly) {
+                        player.isChangingQuantityOnly = false;
                         revert = true;
                     }
-                    ((ICrafting) crafter).sendSlotContents(this, i, itemstack1);
+                    crafter.sendSlotContents(this, i, itemstack1);
                     if (revert) {
                         ((EntityPlayerMP) crafter).isChangingQuantityOnly = true;
                     }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20070

Bug introduced in https://github.com/GTNewHorizons/LogisticsPipes/pull/90/commits/fd52b5a63d9487c89abe806d78e115ba4a5a9293#diff-3ec007b786c8275f06b5c5660a8ad1ec7686a7ce27883d1f3f4b6d5929e72823

`MainProxy` has two methods called `sendToPlayerList` but with a different last parameter (`PlayerCollectionList` and `Iterable<EntityPlayer>`). Before generic injection was enabled, `crafters` was an instance of `List` and thus counted as subclass of `Iterable`. When I enabled generic injection I mistakenly casted `crafters` to `PlayerCollectionList`, causing the reported crash.
`crafters` is now an instance of `List<ICrafting>`. `ICrafting` is implemented by `CreativeCrafting`, `EntityPlayerMP` (which extends `EntityPlayer`) and `GuiRepair`. Because no crashes happend before #90, it's safe to assume that `crafters` only contains objects which an instance of `EntityPlayerMP`. Java doesn't allow casting `List<ICrafting>` -> `Iterable<EntityPlayer>` directly though, so we have to do something dirty and cast to `Object` first.