### PR TITLE
Update OpenComputers signal pushing to use sendToReachable

### DIFF
--- a/src/main/java/logisticspipes/proxy/opencomputers/OpenComputersProxy.java
+++ b/src/main/java/logisticspipes/proxy/opencomputers/OpenComputersProxy.java
@@ -72,10 +72,10 @@ public class OpenComputersProxy implements IOpenComputersProxy {
     @Override
     public void pushSignal(String event, Object[] arguments, IOCTile tile) {
         if (tile.getOCNode() != null) {
-            Object[] data = new Object[1 + arguments.length];
-            data[0] = event;
-            System.arraycopy(arguments, 0, data, 1, arguments.length);
-            ((Node) tile.getOCNode()).sendToNeighbors("computer.signal", data);
+            Object[] signalArgs = new Object[arguments.length + 1];
+            signalArgs[0] = event;
+            System.arraycopy(arguments, 0, signalArgs, 1, arguments.length);
+            ((Node) tile.getOCNode()).sendToReachable("computer.signal", signalArgs);
         }
     }
 


### PR DESCRIPTION
This solved the issue that when OC connect to the pipe through the cable, the message won't be sent through. 


![image](https://github.com/user-attachments/assets/f2cf9dc6-0ca2-450e-a1a6-77f677229fb3)
![image](https://github.com/user-attachments/assets/ef49ddaf-d7e5-489f-b363-febdc1ffdc80)
![image](https://github.com/user-attachments/assets/af91807f-fd70-4071-a1a5-db7fa67321ce)
![image](https://github.com/user-attachments/assets/3f5e8c9a-d8b2-4527-a86b-8068dc2c06d0)
