### PR TITLE
Fix LP `isFluidContainer` and `getFluidFromContainer` 

### DIFF
--- a/src/main/java/logisticspipes/logistics/LogisticsFluidManager.java
+++ b/src/main/java/logisticspipes/logistics/LogisticsFluidManager.java
@@ -68,12 +68,12 @@ public class LogisticsFluidManager implements ILogisticsFluidManager {
         if (stack.getItem().item instanceof LogisticsFluidContainer && stack.getItem().tag != null) {
             return FluidStack.loadFluidStackFromNBT(stack.getItem().tag);
         }
-        
+
         // Support for GregTech fluid containers
         if (stack.getItem().tag != null && stack.getItem().tag.hasKey("GT.FluidContent", 10)) {
             return FluidStack.loadFluidStackFromNBT(stack.getItem().tag.getCompoundTag("GT.FluidContent"));
         }
-        
+
         return null;
     }
 

--- a/src/main/java/logisticspipes/logistics/LogisticsFluidManager.java
+++ b/src/main/java/logisticspipes/logistics/LogisticsFluidManager.java
@@ -68,6 +68,12 @@ public class LogisticsFluidManager implements ILogisticsFluidManager {
         if (stack.getItem().item instanceof LogisticsFluidContainer && stack.getItem().tag != null) {
             return FluidStack.loadFluidStackFromNBT(stack.getItem().tag);
         }
+        
+        // Support for GregTech fluid containers
+        if (stack.getItem().tag != null && stack.getItem().tag.hasKey("GT.FluidContent", 10)) {
+            return FluidStack.loadFluidStackFromNBT(stack.getItem().tag.getCompoundTag("GT.FluidContent"));
+        }
+        
         return null;
     }
 

--- a/src/main/java/logisticspipes/proxy/computers/objects/CCFluidIdentifier.java
+++ b/src/main/java/logisticspipes/proxy/computers/objects/CCFluidIdentifier.java
@@ -45,6 +45,11 @@ public class CCFluidIdentifier implements ILPCCTypeDefinition {
             return ident.getName();
         }
 
+        @CCCommand(description = "Returns the Localized Name of this FluidIdentifier")
+        public String getLocalizedName() {
+            return ident.makeFluidStack(0).getLocalizedName();
+        }
+
         @CCCommand(description = "Returns an ItemIdentifier if one exists for this FluidIdentifier")
         public ItemIdentifier getItemIdentifier() {
             return ident.getItemIdentifier();

--- a/src/main/java/logisticspipes/proxy/opencomputers/OpenComputersProxy.java
+++ b/src/main/java/logisticspipes/proxy/opencomputers/OpenComputersProxy.java
@@ -72,10 +72,10 @@ public class OpenComputersProxy implements IOpenComputersProxy {
     @Override
     public void pushSignal(String event, Object[] arguments, IOCTile tile) {
         if (tile.getOCNode() != null) {
-            Object[] data = new Object[1 + arguments.length];
-            data[0] = event;
-            System.arraycopy(arguments, 0, data, 1, arguments.length);
-            ((Node) tile.getOCNode()).sendToNeighbors("computer.signal", data);
+            Object[] signalArgs = new Object[arguments.length + 1];
+            signalArgs[0] = event;
+            System.arraycopy(arguments, 0, signalArgs, 1, arguments.length);
+            ((Node) tile.getOCNode()).sendToReachable("computer.signal", signalArgs);
         }
     }
 

--- a/src/main/java/logisticspipes/proxy/opencomputers/OpenComputersProxy.java
+++ b/src/main/java/logisticspipes/proxy/opencomputers/OpenComputersProxy.java
@@ -55,17 +55,23 @@ public class OpenComputersProxy implements IOpenComputersProxy {
 
     @Override
     public void handleReadFromNBT(IOCTile tile, NBTTagCompound nbt) {
-        if (tile.getOCNode() != null && ((Node) tile.getOCNode()).host() == tile) {
-            ((Node) tile.getOCNode()).load(nbt.getCompoundTag("oc:node"));
+        if (tile.getOCNode() != null) {
+            Node node = (Node) tile.getOCNode();
+            if (node.host() != null && node.host() == tile) {
+                node.load(nbt.getCompoundTag("oc:node"));
+            }
         }
     }
 
     @Override
     public void handleWriteToNBT(IOCTile tile, NBTTagCompound nbt) {
-        if (tile.getOCNode() != null && ((Node) tile.getOCNode()).host() == tile) {
-            final NBTTagCompound nodeNbt = new NBTTagCompound();
-            ((Node) tile.getOCNode()).save(nodeNbt);
-            nbt.setTag("oc:node", nodeNbt);
+        if (tile.getOCNode() != null) {
+            Node node = (Node) tile.getOCNode();
+            if (node.host() != null && node.host() == tile) {
+                final NBTTagCompound nodeNbt = new NBTTagCompound();
+                node.save(nodeNbt);
+                nbt.setTag("oc:node", nodeNbt);
+            }
         }
     }
 

--- a/src/main/java/logisticspipes/utils/item/ItemIdentifier.java
+++ b/src/main/java/logisticspipes/utils/item/ItemIdentifier.java
@@ -711,7 +711,17 @@ public final class ItemIdentifier implements Comparable<ItemIdentifier>, ILPCCTy
     }
 
     public boolean isFluidContainer() {
-        return item instanceof LogisticsFluidContainer;
+        // Check if it's a Logistics Pipes fluid container
+        if (item instanceof LogisticsFluidContainer) {
+            return true;
+        }
+        
+        // Check if it's a GregTech fluid container (has GT.FluidContent NBT tag)
+        if (tag != null && tag.hasKey("GT.FluidContent", 10)) {
+            return true;
+        }
+        
+        return false;
     }
 
     public DictItemIdentifier getDictIdentifiers() {

--- a/src/main/java/logisticspipes/utils/item/ItemIdentifier.java
+++ b/src/main/java/logisticspipes/utils/item/ItemIdentifier.java
@@ -715,12 +715,12 @@ public final class ItemIdentifier implements Comparable<ItemIdentifier>, ILPCCTy
         if (item instanceof LogisticsFluidContainer) {
             return true;
         }
-        
+
         // Check if it's a GregTech fluid container (has GT.FluidContent NBT tag)
         if (tag != null && tag.hasKey("GT.FluidContent", 10)) {
             return true;
         }
-        
+
         return false;
     }
 


### PR DESCRIPTION
`isFluidContainer` and `getFluidFromContainer` was previously not working for gt fluid container. When OC checks the integration of the LP system, it does not recognise GT fluid containers, such as the "Large Aluminium Cell", as a valid fluid container. 

This PR fixed by adding support for the GT fluid container since this mod will probably only be used in GTNH modpack. 