### PR TITLE
Fix Basic Fluid Pipes counting output tanks as available space to fill

### DIFF
--- a/src/main/java/logisticspipes/pipes/PipeFluidBasic.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidBasic.java
@@ -63,11 +63,10 @@ public class PipeFluidBasic extends FluidRoutedPipe implements IFluidSink {
         int freeSpace = -onTheWay;
 
         for (Pair<TileEntity, ForgeDirection> pair : getAdjacentTanks(true)) {
-            if (!(pair.getValue1() instanceof IFluidHandler)) {
+            if (!(pair.getValue1() instanceof IFluidHandler handler)) {
                 continue;
             }
 
-            IFluidHandler handler = (IFluidHandler) pair.getValue1();
             ForgeDirection dir = pair.getValue2().getOpposite();
 
             // ensure we are actually able to fill this handler, and it's not some output tank or such


### PR DESCRIPTION
If a Basic Fluid pipe was attached to a GT machine, such as a distillery, whose input tank was full and output tank was empty, the pipe would count the machines output tank as available space for it to fill. This would lead to fluid being sent to this pipe that it couldn't actually put anywhere, and if there were nowhere else in the logistics network could redirect the fluid to, the fluid would be voided. This PR checks if the fluid interface can actually be filled before counting it as available space.

This is my first attempt at contributing to the minecraft modding community, and constructive criticism would be welcomed.