### PR TITLE
Fix fluids not being routed to basic fluid pipes connected to entities that void fluids (for instance, a super tank)

### DIFF
--- a/src/main/java/logisticspipes/pipes/PipeFluidBasic.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidBasic.java
@@ -87,6 +87,13 @@ public class PipeFluidBasic extends FluidRoutedPipe implements IFluidSink {
                 continue;
             }
 
+            // some entities that void fluids, like the gt5 super tank, report a capacity of
+            // Integer.MAX_VALUE. that could cause an integer overflow below,
+            // which this early return avoids.
+            if (externalFreeSpace >= stack.amount) {
+                return stack.amount;
+            }
+
             freeSpace += internalFreeSpace;
             freeSpace += externalFreeSpace;
 


### PR DESCRIPTION
Some entities that void fluids will report a capacity of Integer.MAX_VALUE. That caused an overflow when calculating how much fluid a basic pipe could accept, leading to it thinking there was a negative amount of space available, and thus not accepting any fluids.

Previously reported in GTNewHorizons/GT-New-Horizons-Modpack#17222