### PR TITLE
Make Fluid (Provider) Pipe inner and side capacity configurable

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.41'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
 }
 
 

--- a/src/main/java/logisticspipes/config/Configs.java
+++ b/src/main/java/logisticspipes/config/Configs.java
@@ -58,6 +58,9 @@ public class Configs {
 
     public static int MAX_ROBOT_DISTANCE = 64;
 
+    public static int MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY = 10000;
+    public static int MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY = 5000;
+
     private static boolean loaded = false;
 
     public static void load() {
@@ -250,6 +253,22 @@ public class Configs {
         Configs.EASTER_EGGS = Configs.CONFIGURATION
                 .get(Configuration.CATEGORY_GENERAL, "easterEggs", Configs.EASTER_EGGS, "Do you fancy easter eggs?")
                 .getBoolean(false);
+
+        Configs.MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY = Configs.CONFIGURATION
+            .get(
+                Configuration.CATEGORY_GENERAL,
+                "maxLogisticsFluidInnerCapacity",
+                Configs.MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY,
+                "Set the maximum amount for a liquid that can be held in a fluid pipe. Default value: 10000 (1000 equals 1 Bucket for normal fluids). If you are playing GTNH this value represents the liters this number (10000 = 10000L).")
+            .getInt();
+
+        Configs.MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY = Configs.CONFIGURATION
+            .get(
+                Configuration.CATEGORY_GENERAL,
+                "maxLogisticsFluidSideCapacity",
+                Configs.MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY,
+                "Set the maximum amount for a liquid that can be held in each attached side a fluid pipe. This value should be half of 'maxLogisticsFluidInnerCapacity' Default value: 5000 (1000 equals 1 Bucket for normal fluids). If you are playing GTNH this value represents the liters this number (10000 = 10000L).")
+            .getInt();
 
         Configs.CONFIGURATION.save();
     }

--- a/src/main/java/logisticspipes/config/Configs.java
+++ b/src/main/java/logisticspipes/config/Configs.java
@@ -59,7 +59,6 @@ public class Configs {
     public static int MAX_ROBOT_DISTANCE = 64;
 
     public static int MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY = 10000;
-    public static int MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY = 5000;
 
     private static boolean loaded = false;
 
@@ -259,15 +258,7 @@ public class Configs {
                 Configuration.CATEGORY_GENERAL,
                 "maxLogisticsFluidInnerCapacity",
                 Configs.MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY,
-                "Set the maximum amount for a liquid that can be held in a fluid pipe. Default value: 10000 (1000 equals 1 Bucket for normal fluids). If you are playing GTNH this value represents the liters this number (10000 = 10000L).")
-            .getInt();
-
-        Configs.MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY = Configs.CONFIGURATION
-            .get(
-                Configuration.CATEGORY_GENERAL,
-                "maxLogisticsFluidSideCapacity",
-                Configs.MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY,
-                "Set the maximum amount for a liquid that can be held in each attached side a fluid pipe. This value should be half of 'maxLogisticsFluidInnerCapacity' Default value: 5000 (1000 equals 1 Bucket for normal fluids). If you are playing GTNH this value represents the liters this number (10000 = 10000L).")
+                "Sets the maximum amount for a liquid that can be held in a fluid pipe. Default value: 10000 (1000 equals 1 Bucket for normal fluids). If you are playing GTNH this value represents liters (10000 = 10000L).")
             .getInt();
 
         Configs.CONFIGURATION.save();

--- a/src/main/java/logisticspipes/pipes/PipeFluidProvider.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidProvider.java
@@ -14,6 +14,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import logisticspipes.config.Configs;
 import logisticspipes.interfaces.ISpecialTankAccessHandler;
 import logisticspipes.interfaces.ISpecialTankHandler;
 import logisticspipes.interfaces.routing.IAdditionalTargetInformation;
@@ -53,7 +54,8 @@ public class PipeFluidProvider extends FluidRoutedPipe implements IProvideFluids
 
         LogisticsFluidOrder order = getFluidOrderManager().peekAtTopRequest(ResourceType.PROVIDER);
         int amountToSend, attemptedAmount;
-        amountToSend = attemptedAmount = Math.min(order.getAmount(), 5000);
+        amountToSend = attemptedAmount = Math
+                .min(order.getAmount(), Configs.MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY / 2);
         for (Pair<TileEntity, ForgeDirection> pair : getAdjacentTanks(false)) {
             if (amountToSend <= 0) {
                 break;

--- a/src/main/java/logisticspipes/transport/PipeFluidTransportLogistics.java
+++ b/src/main/java/logisticspipes/transport/PipeFluidTransportLogistics.java
@@ -115,7 +115,7 @@ public class PipeFluidTransportLogistics extends PipeTransportLogistics implemen
     }
 
     public int getSideCapacity() {
-        return Configs.MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY;
+        return Configs.MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY / 2;
     }
 
     @Override

--- a/src/main/java/logisticspipes/transport/PipeFluidTransportLogistics.java
+++ b/src/main/java/logisticspipes/transport/PipeFluidTransportLogistics.java
@@ -8,6 +8,7 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import logisticspipes.config.Configs;
 import logisticspipes.network.PacketHandler;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.packets.pipe.PipeFluidUpdate;
@@ -110,11 +111,11 @@ public class PipeFluidTransportLogistics extends PipeTransportLogistics implemen
     }
 
     public int getInnerCapacity() {
-        return 10000;
+        return Configs.MAX_LOGISTICS_FLUID_TRANSPORT_INNER_CAPACITY;
     }
 
     public int getSideCapacity() {
-        return 5000;
+        return Configs.MAX_LOGISTICS_FLUID_TRANSPORT_SIDE_CAPACITY;
     }
 
     @Override


### PR DESCRIPTION
With this PR I want to resolve a little issue here where the mentioned functions are causing trouble when in need from higher fluid throughput.

Best example is the Large Steel Boiler which creates 40kL Steam with 1 Coal at 40kL/s and this fills up +HV hatches quickly enough. This results in a bottleneck for the Logistics Fluid Insertion Pipe sending out only 5000L Fluid packets (here Steam) and also one requests 5000L Fluid Packets (here water). This causes also a huge impact of send packets within the LP Network which can cause TPS drops on large or heavily used LP Networks.

With the new way players can change the default values to a suitable one. Currently the mods default values are used but I suggest to set "maxLogisticsFluidInnerCapacity=64000" and "maxLogisticsFluidSideCapacity=32000" which should reduce the amount of sended fluid packets when used at full capacity size. At last for GTNH these values should be minimum.

Changes made:

Changed getInnerCapacity() and getSideCapactiy() in PipeFluidTransportLogistics.java to be configurable and not hardcoded.
Added maxLogisticsFluidInnerCapacity and maxLogisticsFluidSideCapacity to reflect the new config option with proper description to it.