### PR TITLE
Fix ServerRouter task-queue crash under concurrent computer (OC/CC) access

### DIFF
--- a/src/main/java/logisticspipes/routing/ServerRouter.java
+++ b/src/main/java/logisticspipes/routing/ServerRouter.java
@@ -17,9 +17,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -263,7 +265,7 @@ public class ServerRouter implements IRouter, Comparable<ServerRouter> {
     private boolean destroied = false;
 
     private WeakReference<CoreRoutedPipe> _myPipeCache = null;
-    private final LinkedList<Pair<Integer, IRouterQueuedTask>> queue = new LinkedList<>();
+    private final Queue<Pair<Integer, IRouterQueuedTask>> queue = new ConcurrentLinkedQueue<>();
 
     @Override
     public void clearPipeCache() {
@@ -1264,8 +1266,8 @@ public class ServerRouter implements IRouter, Comparable<ServerRouter> {
     }
 
     private void handleQueuedTasks(CoreRoutedPipe pipe) {
-        while (!queue.isEmpty()) {
-            Pair<Integer, IRouterQueuedTask> element = queue.poll();
+        Pair<Integer, IRouterQueuedTask> element;
+        while ((element = queue.poll()) != null) {
             if (element.getValue1() > MainProxy.getGlobalTick()) {
                 element.getValue2().call(pipe, this);
             }


### PR DESCRIPTION
## Summary

`ServerRouter` stores per-router deferred tasks in a plain `java.util.LinkedList` (`queue`) that is mutated from **two different threads** with no synchronization:

- **added** from the OpenComputers / ComputerCraft **direct-call thread** (`ServerRouter.queueTask`, reached via `CoreRoutedPipe.sendBroadcast` / `sendMessage`), and
- **drained** on the **server tick thread** (`ServerRouter.handleQueuedTasks`, called from `update`).

Concurrent `add` / `poll` on an unsynchronized `LinkedList` corrupts its internal state, which intermittently crashes the server with an NPE. This PR makes the queue thread-safe.

## The crash

```
java.lang.NullPointerException: Cannot invoke "logisticspipes.utils.tuples.Pair.getValue1()" because "element" is null
    at logisticspipes.routing.ServerRouter.handleQueuedTasks(ServerRouter.java:1269)
    at logisticspipes.routing.ServerRouter.update(ServerRouter.java:1244)
    at logisticspipes.pipes.basic.CoreRoutedPipe.updateEntity(CoreRoutedPipe.java:412)
    at logisticspipes.pipes.basic.LogisticsTileGenericPipe.updateEntity(LogisticsTileGenericPipe.java:219)
    at net.minecraft.world.World.updateEntities(World.java:1939)
    ...
-- Block entity being ticked --
    Pipe: logisticspipes.pipes.PipeLogisticsChassiMk2
    Router: ServerRouter: {ID: 18, ...}
    Suspected Mods: Logistics Pipes (LogisticsPipes)
    LP-Version: 1.4.24-GTNH
```

The offending loop:

```java
private void handleQueuedTasks(CoreRoutedPipe pipe) {
    while (!queue.isEmpty()) {                      // server tick thread
        Pair<Integer, IRouterQueuedTask> element = queue.poll();
        if (element.getValue1() > MainProxy.getGlobalTick()) {   // line 1269 -> element == null
            element.getValue2().call(pipe, this);
        }
    }
}
```

`element` is `null` even though `!queue.isEmpty()` was just `true`. The JEP-358 helpful-NPE message names the **receiver** `element` as null (not a null `getValue1()` return), so this is unambiguously `poll()` returning `null` immediately after `isEmpty()` returned `false`.

## What triggers it

An OpenComputers program talking to the LP network. In the reproduction, a requester computer broadcasts discovery / craft requests and every autocrafter computer replies — so `sendBroadcast` is invoked frequently, and (during *rediscovery*) from several computer threads at once.

Requester side — `rediscover` re-broadcasts to the whole network:

```lua
-- broadcast helper
local function broadcastMessage(message)
    local messageStr = serialization.serialize(message)
    if craftingSystem.pipeInterface.sendBroadcast then
        pcall(craftingSystem.pipeInterface.sendBroadcast, messageStr)   -- LP @CCDirectCall
    end
    ...
end

-- shell command
rediscover = function()
    performDiscovery()          -- clears craftables, re-broadcasts discovery_request
end
```

Responder side (autocrafter) replies to every `LP_BROADCAST` from its own event-handler thread:

```lua
event.listen(system.config.broadcast_event_name, system.handleBroadcast)
-- handleBroadcast -> on discovery_request -> pipeInterface.sendBroadcast(discovery_response)
```

## Root cause

`sendBroadcast` / `sendMessage` are annotated `@CCDirectCall`:

```java
// CoreRoutedPipe.java
@CCDirectCall
public void sendBroadcast(final Object message) {
    ...
    for (ExitRoute exit : getRouter().getIRoutersByCost()) {
        if (exit.destination != null && !set.get(exit.destination.getSimpleID())) {
            exit.destination.queueTask(10, (pipe, router) -> pipe.handleBroadcast(message, fSourceId));
            set.set(exit.destination.getSimpleID());
        }
    }
}
```

For OpenComputers, an LP `@CCDirectCall` becomes an OC `@Callback(direct = true)` (generated in `ClassCreator.addMethod`, gated in `BaseWrapperClass`). **OC executes `direct = true` callbacks inline on the computer's executor thread, not on the server thread** (`Machine.invoke` runs the callback on the calling Lua/computer-pool thread; only `direct = false` callbacks are run from `update()` on the server thread; budget exhaustion throws `LimitReachedException` and yields rather than promoting the in-flight call to the server thread).

So `sendBroadcast` walks every router and calls:

```java
public void queueTask(int i, IRouterQueuedTask callable) {
    queue.add(new Pair<>(i + MainProxy.getGlobalTick(), callable));   // computer thread, no lock
}
```

while the server tick thread is simultaneously running `handleQueuedTasks` (`isEmpty()` + `poll()`) on the **same** `LinkedList`. `LinkedList`'s `size` / `first` / `last` fields are non-volatile and updated non-atomically, so a reader can observe `size > 0` while `first` is still `null` → `isEmpty()` is `false` but `poll()` returns `null` → NPE. (A single concurrent `add` colliding with one `poll` is sufficient; multiple computers broadcasting during rediscovery just widen the window.)

Note the sibling queue `logisticspipes.ticks.QueuedTasks` guards exactly this pattern with `synchronized` on both `add` and the drain — `ServerRouter.queue` simply never got the same treatment.

## The fix

Replace the unsynchronized `LinkedList` with a thread-safe `ConcurrentLinkedQueue`, and drain with a null-checked `poll()` instead of `isEmpty()` + `poll()`:

```java
private final Queue<Pair<Integer, IRouterQueuedTask>> queue = new ConcurrentLinkedQueue<>();

private void handleQueuedTasks(CoreRoutedPipe pipe) {
    Pair<Integer, IRouterQueuedTask> element;
    while ((element = queue.poll()) != null) {
        if (element.getValue1() > MainProxy.getGlobalTick()) {
            element.getValue2().call(pipe, this);
        }
    }
}
```

Why this is correct and sufficient:

- `ConcurrentLinkedQueue.add` / `poll` are lock-free and thread-safe, so the cross-thread `queueTask` (producer) vs `handleQueuedTasks` (consumer) access is safe.
- `while ((element = queue.poll()) != null)` removes the check-then-act (`isEmpty()`-then-`poll()`) race entirely: `poll()` atomically returns an element or `null`.
- Each task is delivered to exactly one consumer, so there is no double execution even if a second drainer ever appeared.
- Task ordering is not a correctness requirement here, and the existing `getValue1() > getGlobalTick()` gate is left unchanged.

## Notes

- Developed/committed against current `master`; the crash above is from `1.4.24-GTNH`, but the relevant code (`ServerRouter.java:266`, `1266`-`1273`, `1595`-`1596`) is identical at HEAD, so the bug is still live and the fix applies unchanged.
- Diagnosis independently re-verified against the OpenComputers source for the direct-call threading model.
