### PR TITLE
Add ComputerCraft/OpenComputers commands to the Fluid Request pipe

### DIFF
--- a/src/main/java/logisticspipes/pipes/PipeFluidRequestLogistics.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidRequestLogistics.java
@@ -77,16 +77,6 @@ public class PipeFluidRequestLogistics extends FluidRoutedPipe implements IReque
         return false;
     }
 
-    /*
-     * CC/OC: makeRequest / getFluidAmount take a FluidIdentifier OBJECT (like the item pipe's ItemIdentifier).
-     * Construct one computer-side with LP.getFluidIdentifierBuilder() (mirrors getItemIdentifierBuilder()):
-     * setFluidName("water") then build(). makeRequest's amount is a whole-number Long (mB) matching makeStack(Long
-     * stackSize) - pass a Lua integer like 1, not 1.0. getAvailableFluids() deliberately returns a plain registry-name
-     * -> mB table (NOT FluidIdentifier objects) so it is always safe to serialize/print on the computer: returning
-     * fluid objects here would let a naive recursive dumper hit the FluidIdentifier <-> container-ItemIdentifier getter
-     * cycle (getItemIdentifier() <-> getFluidContainer()) and StackOverflow. Trade-off: NBT-tagged fluid variants
-     * collapse to their base name in the listing (rebuild from name addresses only the untagged variant).
-     */
     @CCCommand(description = "Requests the given amount (mB) of the given FluidIdentifier")
     @CCQueued
     public Object[] makeRequest(FluidIdentifier fluid, Long amount) throws Exception {

--- a/src/main/java/logisticspipes/pipes/PipeFluidRequestLogistics.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidRequestLogistics.java
@@ -1,5 +1,9 @@
 package logisticspipes.pipes;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeSet;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.util.ChatComponentText;
@@ -10,11 +14,17 @@ import logisticspipes.network.GuiIDs;
 import logisticspipes.pipes.basic.fluid.FluidRoutedPipe;
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.proxy.SimpleServiceLocator;
+import logisticspipes.proxy.computers.interfaces.CCCommand;
+import logisticspipes.proxy.computers.interfaces.CCQueued;
+import logisticspipes.proxy.computers.interfaces.CCType;
+import logisticspipes.request.RequestHandler;
 import logisticspipes.security.SecuritySettings;
 import logisticspipes.textures.Textures;
 import logisticspipes.textures.Textures.TextureType;
 import logisticspipes.utils.FluidIdentifier;
+import logisticspipes.utils.item.ItemIdentifierStack;
 
+@CCType(name = "LogisticsPipes:FluidRequest")
 public class PipeFluidRequestLogistics extends FluidRoutedPipe implements IRequestFluid {
 
     public PipeFluidRequestLogistics(Item item) {
@@ -65,5 +75,60 @@ public class PipeFluidRequestLogistics extends FluidRoutedPipe implements IReque
     @Override
     public boolean canReceiveFluid() {
         return false;
+    }
+
+    /*
+     * CC/OC: makeRequest / getFluidAmount take a FluidIdentifier OBJECT (like the item pipe's ItemIdentifier).
+     * Construct one computer-side with LP.getFluidIdentifierBuilder() (mirrors getItemIdentifierBuilder()):
+     * setFluidName("water") then build(). makeRequest's amount is a whole-number Long (mB) matching makeStack(Long
+     * stackSize) - pass a Lua integer like 1, not 1.0. getAvailableFluids() deliberately returns a plain registry-name
+     * -> mB table (NOT FluidIdentifier objects) so it is always safe to serialize/print on the computer: returning
+     * fluid objects here would let a naive recursive dumper hit the FluidIdentifier <-> container-ItemIdentifier getter
+     * cycle (getItemIdentifier() <-> getFluidContainer()) and StackOverflow. Trade-off: NBT-tagged fluid variants
+     * collapse to their base name in the listing (rebuild from name addresses only the untagged variant).
+     */
+    @CCCommand(description = "Requests the given amount (mB) of the given FluidIdentifier")
+    @CCQueued
+    public Object[] makeRequest(FluidIdentifier fluid, Long amount) throws Exception {
+        if (fluid == null) {
+            throw new Exception("Invalid FluidIdentifier");
+        }
+        if (amount == null) {
+            throw new Exception("Invalid amount");
+        }
+        return RequestHandler.computerFluidRequest(fluid, amount.intValue(), this, this);
+    }
+
+    @CCCommand(description = "Returns a table of available fluid registry-name -> amount (mB) in the network")
+    @CCQueued
+    public Map<String, Integer> getAvailableFluids() {
+        TreeSet<ItemIdentifierStack> fluids = SimpleServiceLocator.logisticsFluidManager
+                .getAvailableFluid(getRouter().getIRoutersByCost());
+        Map<String, Integer> result = new HashMap<>();
+        for (ItemIdentifierStack stack : fluids) {
+            FluidIdentifier fluid = FluidIdentifier.get(stack.getItem());
+            if (fluid == null) {
+                continue;
+            }
+            result.merge(fluid.getName(), stack.getStackSize(), Integer::sum);
+        }
+        return result;
+    }
+
+    @CCCommand(description = "Asks for the available amount (mB) of the given FluidIdentifier")
+    @CCQueued
+    public int getFluidAmount(FluidIdentifier fluid) throws Exception {
+        if (fluid == null) {
+            throw new Exception("Invalid FluidIdentifier");
+        }
+        TreeSet<ItemIdentifierStack> fluids = SimpleServiceLocator.logisticsFluidManager
+                .getAvailableFluid(getRouter().getIRoutersByCost());
+        int total = 0;
+        for (ItemIdentifierStack stack : fluids) {
+            if (fluid.equals(FluidIdentifier.get(stack.getItem()))) {
+                total += stack.getStackSize();
+            }
+        }
+        return total;
     }
 }

--- a/src/main/java/logisticspipes/proxy/computers/objects/CCFluidIdentifierBuilder.java
+++ b/src/main/java/logisticspipes/proxy/computers/objects/CCFluidIdentifierBuilder.java
@@ -1,0 +1,49 @@
+package logisticspipes.proxy.computers.objects;
+
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+import logisticspipes.proxy.computers.interfaces.CCCommand;
+import logisticspipes.proxy.computers.interfaces.CCType;
+import logisticspipes.proxy.computers.interfaces.ILPCCTypeHolder;
+import logisticspipes.utils.FluidIdentifier;
+
+@CCType(name = "FluidIdentifierBuilder")
+public class CCFluidIdentifierBuilder implements ILPCCTypeHolder {
+
+    private Object ccType;
+
+    private String fluidName = null;
+
+    @CCCommand(description = "Set the Forge registry name (e.g. water, molten.rubber) for this FluidIdentifierBuilder")
+    public void setFluidName(String name) {
+        fluidName = name;
+    }
+
+    @CCCommand(description = "Returns the Forge registry name for this FluidIdentifierBuilder")
+    public String getFluidName() {
+        return fluidName;
+    }
+
+    @CCCommand(description = "Returns the FluidIdentifier for this FluidIdentifierBuilder")
+    public FluidIdentifier build() {
+        if (fluidName == null) {
+            throw new UnsupportedOperationException("No fluid name set");
+        }
+        FluidStack stack = FluidRegistry.getFluidStack(fluidName, 1);
+        if (stack == null) {
+            throw new UnsupportedOperationException("Not a valid FluidIdentifier: " + fluidName);
+        }
+        return FluidIdentifier.get(stack);
+    }
+
+    @Override
+    public void setCCType(Object type) {
+        ccType = type;
+    }
+
+    @Override
+    public Object getCCType() {
+        return ccType;
+    }
+}

--- a/src/main/java/logisticspipes/proxy/computers/objects/LPGlobalCCAccess.java
+++ b/src/main/java/logisticspipes/proxy/computers/objects/LPGlobalCCAccess.java
@@ -44,6 +44,11 @@ public class LPGlobalCCAccess implements ILPCCTypeHolder {
         return new CCItemIdentifierBuilder();
     }
 
+    @CCCommand(description = "Creates a new FluidIdentifier Builder")
+    public CCFluidIdentifierBuilder getFluidIdentifierBuilder() {
+        return new CCFluidIdentifierBuilder();
+    }
+
     @Override
     public void setCCType(Object type) {
         ccType = type;

--- a/src/main/java/logisticspipes/proxy/opencomputers/asm/BaseWrapperClass.java
+++ b/src/main/java/logisticspipes/proxy/opencomputers/asm/BaseWrapperClass.java
@@ -12,6 +12,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
@@ -27,6 +29,8 @@ import logisticspipes.proxy.computers.interfaces.CCCommand;
 import logisticspipes.proxy.computers.interfaces.CCDirectCall;
 import logisticspipes.proxy.computers.interfaces.CCQueued;
 import logisticspipes.proxy.computers.interfaces.ICCTypeWrapped;
+import logisticspipes.proxy.computers.objects.CCFluidIdentifier.CCFluidIdentifierImplementation;
+import logisticspipes.proxy.computers.objects.CCFluidIdentifierBuilder;
 import logisticspipes.proxy.computers.objects.CCItemIdentifier.CCItemIdentifierImplementation;
 import logisticspipes.proxy.computers.objects.CCItemIdentifierBuilder;
 import logisticspipes.proxy.computers.objects.CCItemIdentifierStack.CCItemIdentifierStackImplementation;
@@ -36,6 +40,7 @@ import logisticspipes.proxy.computers.wrapper.CCWrapperInformation;
 import logisticspipes.proxy.computers.wrapper.ICommandWrapper;
 import logisticspipes.security.PermissionException;
 import logisticspipes.ticks.QueuedTasks;
+import logisticspipes.utils.FluidIdentifier;
 import logisticspipes.utils.item.ItemIdentifier;
 import logisticspipes.utils.item.ItemIdentifierStack;
 import logisticspipes.utils.tuples.LPPosition;
@@ -430,6 +435,17 @@ public abstract class BaseWrapperClass extends AbstractValue {
                 object = builder;
                 checkType();
             }
+        } else if ("CCFluidIdentifierImplementation".equals(type)) {
+            FluidStack stack = FluidRegistry.getFluidStack(nbt.getString("FluidName"), 1);
+            if (stack != null) {
+                object = new CCFluidIdentifierImplementation(FluidIdentifier.get(stack));
+                checkType();
+            }
+        } else if ("CCFluidIdentifierBuilder".equals(type)) {
+            CCFluidIdentifierBuilder builder = new CCFluidIdentifierBuilder();
+            builder.setFluidName(nbt.getString("FluidName"));
+            object = builder;
+            checkType();
         } else if ("LogisticsSolidTileEntity".equals(type)) {
             int x = nbt.getInteger("X");
             int y = nbt.getInteger("Y");
@@ -475,6 +491,13 @@ public abstract class BaseWrapperClass extends AbstractValue {
         } else if (object instanceof CCItemIdentifierBuilder) {
             nbt.setString("Type", "CCItemIdentifierBuilder");
             ((CCItemIdentifierBuilder) object).build().makeNormalStack(1).writeToNBT(nbt);
+        } else if (object instanceof CCFluidIdentifierImplementation) {
+            nbt.setString("Type", "CCFluidIdentifierImplementation");
+            nbt.setString("FluidName", ((CCFluidIdentifierImplementation) object).getObject().getName());
+        } else if (object instanceof CCFluidIdentifierBuilder) {
+            nbt.setString("Type", "CCFluidIdentifierBuilder");
+            String name = ((CCFluidIdentifierBuilder) object).getFluidName();
+            nbt.setString("FluidName", name == null ? "" : name);
         } else if (object instanceof LogisticsSolidTileEntity) {
             LPPosition pos = ((LogisticsSolidTileEntity) object).getLPPosition();
             nbt.setString("Type", "LogisticsSolidTileEntity");

--- a/src/main/java/logisticspipes/request/RequestHandler.java
+++ b/src/main/java/logisticspipes/request/RequestHandler.java
@@ -234,6 +234,35 @@ public class RequestHandler {
         return status;
     }
 
+    public static Object[] computerFluidRequest(final FluidIdentifier fluid, final int amount,
+            final CoreRoutedPipe pipe, final IRequestFluid requester) {
+
+        if (!pipe.useEnergy(10)) {
+            return new Object[] { "NO_POWER" };
+        }
+        final Object[] status = new Object[2];
+        RequestTree.requestFluid(fluid, amount, requester, new RequestLog() {
+
+            @Override
+            public void handleMissingItems(List<IResource> resources) {
+                status[0] = "MISSING";
+                status[1] = resources;
+            }
+
+            @Override
+            public void handleSucessfullRequestOf(IResource item, LinkedLogisticsOrderList parts) {
+                status[0] = "DONE";
+                List<IResource> itemList = new LinkedList<>();
+                itemList.add(item);
+                status[1] = itemList;
+            }
+
+            @Override
+            public void handleSucessfullRequestOfList(List<IResource> resources, LinkedLogisticsOrderList parts) {}
+        });
+        return status;
+    }
+
     public static void refreshFluid(EntityPlayer player, CoreRoutedPipe pipe) {
         TreeSet<ItemIdentifierStack> _allItems = SimpleServiceLocator.logisticsFluidManager
                 .getAvailableFluid(pipe.getRouter().getIRoutersByCost());


### PR DESCRIPTION
## What

The fluid Request pipe (`PipeFluidRequestLogistics`) had no ComputerCraft/OpenComputers integration, unlike the item Request pipe (`PipeItemsRequestLogistics`). This adds a symmetric CC/OC interface so a computer can query and request fluids from the logistics network.

## Commands added

On the **FluidRequest** pipe (`@CCType "LogisticsPipes:FluidRequest"`):

- `makeRequest(fluid, amount)` → `NO_POWER` / `DONE` / `MISSING` — requests `amount` mB of a `FluidIdentifier`.
- `getFluidAmount(fluid)` → mB of a `FluidIdentifier` available in the network.
- `getAvailableFluids()` → a `{ registryName = mB }` table.

On **LP Global Access**:

- `getFluidIdentifierBuilder()` → a `FluidIdentifierBuilder` (`setFluidName(name)` then `build()`), mirroring `getItemIdentifierBuilder()`, so a computer can construct a `FluidIdentifier` by Forge registry name.

## Design notes

- **`makeRequest` / `getFluidAmount` take a `FluidIdentifier` object** (the way the item pipe takes an `ItemIdentifier`). The amount is typed `Long` (mB) to match LP's existing `makeStack(Long stackSize)` convention, so a plain Lua integer matches the parameter (a `Double` would only match a float literal).
- **`getAvailableFluids()` deliberately returns a plain name→mB table, not `FluidIdentifier` objects.** Returning fluid objects would expose the `FluidIdentifier` ↔ container-`ItemIdentifier` getter cycle (`getItemIdentifier()` ↔ `getFluidContainer()`) to a naive recursive serializer on the Lua side and `StackOverflow`. Trade-off: NBT-tagged variants collapse to their base name in the listing (rebuild-from-name addresses the untagged variant; a tagged object can still be passed directly).
- `RequestHandler.computerFluidRequest()` is the player-agnostic request entry point, mirroring `computerRequest()`.
- `BaseWrapperClass` gains save/load parity so fluid OC values persist across world save like item values do.

## Testing

Verified in-game (GTNH 2.8.4, OpenComputers): the builder constructs a fluid by name, `getFluidAmount` returns the correct mB, `getAvailableFluids` lists the network's fluids, and `makeRequest(glue, 1)` returns `DONE` and physically delivers 1 mB into the tank adjacent to the pipe (network stock decremented by exactly 1).

<img width="889" height="967" alt="image" src="https://github.com/user-attachments/assets/3969e2ec-eb09-4988-9533-9adb6e93843b" />

<img width="1546" height="1288" alt="image" src="https://github.com/user-attachments/assets/18ae22b0-2a55-43c7-97b1-35c1bc300a38" />


```lua

--
-- probe_pull_glue.lua - request 1 mB of glue from the LP network via the
-- FluidRequest pipe's makeRequest(FluidIdentifier, Double), then watch the tank
-- on the WEST side of the transposer to see whether it actually arrives there.
--
-- *** HAS SIDE EFFECTS *** this performs a REAL LP fluid request (pulls 1 mB glue
-- into the network's delivery target). Everything else (reads) is harmless.
--
-- It also scans all 6 transposer sides before/after, so if the glue lands
-- somewhere other than west we still see where makeRequest deposits it.
--
-- Run:  probe_pull_glue      Output: ./probe_pull_glue.log
--

local component     = require("component")
local serialization = require("serialization")
local sides         = require("sides")

local WEST = sides.west   -- 4
local SIDE_NAME = { [0]="down", [1]="up", [2]="north", [3]="south", [4]="west", [5]="east" }

local out = {}
local function log(s) s = tostring(s); out[#out + 1] = s; print(s) end
local function save()
    local f = io.open("./probe_pull_glue.log", "w")
    if f then f:write(table.concat(out, "\n") .. "\n"); f:close() end
end
local function ser(v)
    if type(v) == "table" then local ok, r = pcall(serialization.serialize, v); return ok and r or tostring(v) end
    return tostring(v)
end

-- transposer
local tAddr = component.list("transposer")()
if not tAddr then log("no transposer found - abort"); save(); return end
local trans = component.proxy(tAddr)
log("transposer = " .. tAddr)
log("WEST side  = " .. tostring(WEST) .. " (" .. (SIDE_NAME[WEST] or "?") .. ")")

local function fluidOnSide(side)
    local okC, cnt = pcall(trans.getTankCount, side)
    local okF, fl  = pcall(trans.getFluidInTank, side)
    return string.format("count=%s  fluid=%s", okC and tostring(cnt) or "?", okF and ser(fl) or "ERR")
end
local function readWest(tag)
    log(string.format("  [%s] WEST -> %s", tag, fluidOnSide(WEST)))
end
local function scanAllSides(tag)
    log("  -- all-sides fluid scan (" .. tag .. ") --")
    for s = 0, 5 do
        log(string.format("     side %d %-5s : %s", s, SIDE_NAME[s] or "?", fluidOnSide(s)))
    end
end

-- FluidRequest pipe
local fpipe, fAddr
for addr in component.list("logisticspipe") do
    local lp = component.proxy(addr)
    local ok, pipe = pcall(lp.getPipe)
    if ok and pipe and pipe.getFluidAmount ~= nil then fpipe = pipe; fAddr = addr; break end
end
log("FluidRequest pipe = " .. tostring(fAddr))
if not fpipe then log("no FluidRequest pipe - abort"); save(); return end

-- build the glue FluidIdentifier (proven recipe from probe_fluid_pipe2)
local okL, glp = pcall(fpipe.getLP)
if not (okL and glp and glp.getFluidIdentifierBuilder ~= nil) then
    log("no glp.getFluidIdentifierBuilder() - abort"); save(); return
end
local b = glp.getFluidIdentifierBuilder()
b.setFluidName("glue")
local okB, glueFid = pcall(b.build)
log("build glue FluidIdentifier ok=" .. tostring(okB) .. " -> " .. ser(glueFid))
if not (okB and glueFid ~= nil) then log("build failed - abort"); save(); return end

-- BEFORE
log("")
log("=== BEFORE ===")
local okA, amtBefore = pcall(fpipe.getFluidAmount, glueFid)
log("  getFluidAmount(glue) ok=" .. tostring(okA) .. " -> " .. tostring(amtBefore) .. " mB (network stock)")
readWest("before")
scanAllSides("before")
save()

-- REQUEST 1 mB
log("")
log("=== makeRequest(glue, 1) ===")
-- amount is a Long (mB) now - pass a plain integer 1 (a float 1.0 would box as Double and NOT match).
-- capture the 3rd return too: on an OC method-match failure that slot holds the error string.
local okR, res, extra = pcall(fpipe.makeRequest, glueFid, 1)
log("  ok=" .. tostring(okR) .. "  result=" .. tostring(res) .. "  extra=" .. tostring(extra))
save()

-- watch the west tank for a few seconds (LP delivery is not instant)
log("")
log("=== AFTER (poll WEST up to ~6s) ===")
for i = 1, 6 do
    os.sleep(1)
    readWest("t+" .. i .. "s")
    save()
end

-- full scan + network delta
log("")
scanAllSides("after")
local okA2, amtAfter = pcall(fpipe.getFluidAmount, glueFid)
log("  getFluidAmount(glue) AFTER ok=" .. tostring(okA2) .. " -> " .. tostring(amtAfter) .. " mB (network stock)")
if okA and okA2 and type(amtBefore) == "number" and type(amtAfter) == "number" then
    log("  network delta = " .. tostring(amtAfter - amtBefore) .. " mB")
end
save()

log("")
log("wrote ./probe_pull_glue.log - paste it back")
save()
print("done -> ./probe_pull_glue.log")

```


Produces logs:

```
transposer = 389a1343-98b6-4c85-a57b-64127769ee20
WEST side  = 4 (west)
FluidRequest pipe = 53036d48-b47b-4e1d-8c9e-4718c87633f3
build glue FluidIdentifier ok=true -> FluidIdentifier: glue/47:null

=== BEFORE ===
  getFluidAmount(glue) ok=true -> 16000 mB (network stock)
  [before] WEST -> count=1  fluid={{amount=0,capacity=16000}}
  -- all-sides fluid scan (before) --
     side 0 down  : count=2  fluid={{amount=0,capacity=32000},{amount=0,capacity=32000}}
     side 1 up    : count=nil  fluid=nil
     side 2 north : count=0  fluid={}
     side 3 south : count=0  fluid={}
     side 4 west  : count=1  fluid={{amount=0,capacity=16000}}
     side 5 east  : count=0  fluid={}

=== makeRequest(glue, 1) ===
  ok=true  result=DONE  extra=table: 0000021162493730

=== AFTER (poll WEST up to ~6s) ===
  [t+1s] WEST -> count=1  fluid={{amount=0,capacity=16000}}
  [t+2s] WEST -> count=1  fluid={{amount=0,capacity=16000}}
  [t+3s] WEST -> count=1  fluid={{label="Glue",capacity=16000,amount=1,hasTag=false,name="glue"}}
  [t+4s] WEST -> count=1  fluid={{label="Glue",capacity=16000,amount=1,hasTag=false,name="glue"}}
  [t+5s] WEST -> count=1  fluid={{label="Glue",capacity=16000,amount=1,hasTag=false,name="glue"}}
  [t+6s] WEST -> count=1  fluid={{label="Glue",capacity=16000,amount=1,hasTag=false,name="glue"}}

  -- all-sides fluid scan (after) --
     side 0 down  : count=2  fluid={{amount=0,capacity=32000},{amount=0,capacity=32000}}
     side 1 up    : count=nil  fluid=nil
     side 2 north : count=0  fluid={}
     side 3 south : count=0  fluid={}
     side 4 west  : count=1  fluid={{label="Glue",capacity=16000,amount=1,hasTag=false,name="glue"}}
     side 5 east  : count=0  fluid={}
  getFluidAmount(glue) AFTER ok=true -> 15999 mB (network stock)
  network delta = -1 mB

wrote ./probe_pull_glue.log - paste it back

```
