### PR TITLE
Fix scroll input in request pipes

### DIFF
--- a/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
+++ b/src/main/java/logisticspipes/utils/gui/ItemDisplay.java
@@ -381,10 +381,12 @@ public class ItemDisplay {
     public void handleMouse() {
         boolean isShift = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
         boolean isControl = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
-        int wheel = Mouse.getEventDWheel();
-        if (wheel == 0) {
+        int rawWheel = Mouse.getEventDWheel();
+        if (rawWheel == 0) {
             return;
         }
+        // Convert the raw notch delta (+-120 on X11 (maybe also Windows & macOS), +-1 on Wayland) to a single step
+        int wheel = rawWheel > 0 ? 1 : -1;
 
         if (isShift && !isControl && isShiftPageChange()) {
             if (wheel > 0) {


### PR DESCRIPTION
## Summary
Fixes mouse scroll input in Logistics Request Pipes or Blocks on X11. When scrolling in these blocks to specify the amount of items to request, the selected amounts gets increased by about 100-200 items per scroll input.
This was previously broken in #78 by fixing scroll input for Wayland. This PR should work for both and also other platforms such as Windows and macOS (though I haven't tested them and don't know if #78 has broken them as well).

In the "original" LP code the raw wheel input from `Mouse.getEventDWheel()` was simply divided by 120. This breaks for Wayland, as the wheel input seems to be just +-1, resulting in no increase / decrease.

This PR simply checks if the value from `Mouse.getEventDWheel()` is positive or negative by setting it to either 1 or -1, so each scroll input will result in the addition or removal of one request item, no matter how much delta is present.

The other locations that #78 modified are fine, because the delta is already checked for being positive or negative before being used further.

I could only test this on X11, so testing it on other platforms before merging might be wise.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
