### PR TITLE
Fix active supplier module for multiple inventories

### DIFF
--- a/src/main/java/logisticspipes/modules/ModuleActiveSupplier.java
+++ b/src/main/java/logisticspipes/modules/ModuleActiveSupplier.java
@@ -222,7 +222,41 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             }
         }
 
+        IInventoryUtil invUtil = getSingleInventory();
+        if (invUtil == null) {
+            return;
+        }
+
+        if (_service.getUpgradeManager(slot, positionInt).hasPatternUpgrade()) {
+            createPatternRequest(invUtil);
+        } else {
+            createSupplyRequest(invUtil);
+        }
+
+    }
+
+    /**
+     * Returns the single inventory that this module is attached to, or null if this inventory cannot be determined.
+     * 
+     * @return
+     */
+    private IInventoryUtil getSingleInventory() {
+        // This will only work for modules in a chassis
+        IInventory realInventory = _service.getRealInventory();
+        ForgeDirection connectionDir = _service.inventoryOrientation();
+        if (realInventory != null && realInventory.getSizeInventory() > 0
+                && connectionDir != null
+                && connectionDir != ForgeDirection.UNKNOWN) {
+            connectionDir = connectionDir.getOpposite();
+            if (_service.getUpgradeManager(slot, positionInt).hasSneakyUpgrade()) {
+                connectionDir = _service.getUpgradeManager(slot, positionInt).getSneakyOrientation();
+            }
+            return SimpleServiceLocator.inventoryUtilFactory.getInventoryUtil(realInventory, connectionDir);
+        }
+
+        // This will only work for a supplier pipe
         WorldUtil worldUtil = new WorldUtil(_world.getWorld(), getX(), getY(), getZ());
+        IInventoryUtil connectedInventory = null;
         for (AdjacentTile tile : worldUtil.getAdjacentTileEntities(true)) {
             if (!(tile.tile instanceof IInventory)) {
                 continue;
@@ -232,18 +266,20 @@ public class ModuleActiveSupplier extends LogisticsGuiModule
             if (inv.getSizeInventory() < 1) {
                 continue;
             }
-            ForgeDirection dir = tile.orientation;
-            if (_service.getUpgradeManager(slot, positionInt).hasSneakyUpgrade()) {
-                dir = _service.getUpgradeManager(slot, positionInt).getSneakyOrientation();
-            }
-            IInventoryUtil invUtil = SimpleServiceLocator.inventoryUtilFactory.getInventoryUtil(inv, dir);
 
-            if (_service.getUpgradeManager(slot, positionInt).hasPatternUpgrade()) {
-                createPatternRequest(invUtil);
-            } else {
-                createSupplyRequest(invUtil);
+            if (connectedInventory != null) {
+                _service.spawnParticle(Particles.RedParticle, 2);
+                return null; // More than one inventory found
             }
+
+            ForgeDirection tileDir = tile.orientation;
+            if (_service.getUpgradeManager(slot, positionInt).hasSneakyUpgrade()) {
+                tileDir = _service.getUpgradeManager(slot, positionInt).getSneakyOrientation();
+            }
+            connectedInventory = SimpleServiceLocator.inventoryUtilFactory.getInventoryUtil(inv, tileDir);
         }
+
+        return connectedInventory;
     }
 
     private void createPatternRequest(IInventoryUtil invUtil) {


### PR DESCRIPTION
## The problem
Both the active supplier module and the supplier pipe do not work well when connected to multiple inventories at once.
The supplier pipe will randomly distribute its items over all connected inventories instead of only delivering to inventories below the supply threshold.
The active supplier module will deliver its items to only the inventory marked with orange dots on the chassis but will base the logic for if it needs to request items on whether any adjacent inventory falls below the supply threshold.
This effectively makes all active supplier modules next to multiple inventories function as if their supply mode is set to infinite, regardless of the actual settings, and debugging the root cause of this behaviour can take quite a lot of time (at least it did for me).

## The solution
I have fixed the issue with the supplier module by merging the logic of the active supplier module with that of the extractor module, which has related functionality and does not have this problem.
Because the supplier pipe uses the code of the active supplier module internally, but does not have any of the logic for detecting connected inventories, I also kept the old functionality as a fallback.

To keep the code simple, it currently only supports supplying to a single connected inventory.
If the supplier pipe is connected to multiple or no inventories, it will instead send out red particles to signify a problem, which I believe is better than the old behaviour of quietly doing the wrong thing and filling the network with wrong supply requests.
I am a bit worried that this might induce a case of [spacebar heating](https://xkcd.com/1172/), but other solutions would require more drastic changes to the codebase, which I am not very familiar with.

I could not find any documentation for the code, so it is very possible that I missed some relevant interface/method that would help here.
Any feedback is appreciated.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ x ] I have tested this PR in Fullpack
- [ x ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
