### PR TITLE
Fix a bad interaction with LP, RFB, and thermal.  Removes old unused checksum related code.

### DIFF
--- a/src/main/java/logisticspipes/LogisticsPipes.java
+++ b/src/main/java/logisticspipes/LogisticsPipes.java
@@ -342,7 +342,6 @@ public class LogisticsPipes {
         isGTNH = Loader.isModLoaded("dreamcraft") && Loader.isModLoaded("gregtech");
 
         LogisticsPipes.log = evt.getModLog();
-        loadClasses();
         ProxyManager.load();
         Configs.load();
         SimpleServiceLocator.setPipeInformationManager(new PipeInformationManager());
@@ -552,25 +551,6 @@ public class LogisticsPipes {
         if (parts != null) {
             SimpleServiceLocator.cofhPowerProxy.addCraftingRecipes(parts);
         }
-    }
-
-    private void loadClasses() {
-        // Try to load all classes to let out checksums get generated
-        forName("net.minecraft.tileentity.TileEntity");
-        forName("net.minecraft.world.World");
-        forName("net.minecraft.item.ItemStack");
-        forName("net.minecraftforge.fluids.FluidStack");
-        forName("net.minecraftforge.fluids.Fluid");
-        forName("dan200.computercraft.core.lua.LuaJLuaMachine");
-        forName("cofh.thermaldynamics.block.TileTDBase");
-        forName("cofh.thermaldynamics.duct.item.TravelingItem");
-        forName("cofh.thermaldynamics.render.RenderDuctItems");
-    }
-
-    private void forName(String string) {
-        try {
-            Class.forName(string);
-        } catch (Exception ignore) {}
     }
 
     @EventHandler


### PR DESCRIPTION
Fixes a class not found exception for a client class on the server with LP + RFB + thermal

```
[19:13:58] [Server thread/ERROR] [FML/]: Caught exception from LogisticsPipes
java.lang.NoClassDefFoundError: net/minecraft/client/renderer/tileentity/TileEntitySpecialRenderer
	at java.base/java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.base/java.lang.ClassLoader.defineClass(Unknown Source) ~[?:?]
	at java.base/java.security.SecureClassLoader.defineClass(Unknown Source) ~[?:?]
	at System//net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:334) ~[LaunchClassLoader.class:?]
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Unknown Source) ~[?:?]
	at java.base/java.lang.Class.forName(Unknown Source) ~[?:?]
	at Launch//logisticspipes.LogisticsPipes.forName(LogisticsPipes.java:572) ~[LogisticsPipes.class:?]
	at Launch//logisticspipes.LogisticsPipes.loadClasses(LogisticsPipes.java:567) ~[LogisticsPipes.class:?]
	at Launch//logisticspipes.LogisticsPipes.preInit(LogisticsPipes.java:345) ~[LogisticsPipes.class:?]
	...
Caused by: java.lang.ClassNotFoundException: net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer in invalid class cache
```

Error reported here: https://discord.com/channels/181078474394566657/603348502637969419/1528182591503466548

