### PR TITLE
Load pipe models in init stage

### DIFF
--- a/src/main/java/logisticspipes/LogisticsPipes.java
+++ b/src/main/java/logisticspipes/LogisticsPipes.java
@@ -133,6 +133,7 @@ import logisticspipes.renderer.FluidContainerRenderer;
 import logisticspipes.renderer.ItemModuleRenderer;
 import logisticspipes.renderer.LogisticsHUDRenderer;
 import logisticspipes.renderer.LogisticsPipeItemRenderer;
+import logisticspipes.renderer.newpipe.LogisticsNewRenderPipe;
 import logisticspipes.routing.RouterManager;
 import logisticspipes.routing.ServerRouter;
 import logisticspipes.routing.pathfinder.PipeInformationManager;
@@ -330,6 +331,7 @@ public class LogisticsPipes {
         FMLCommonHandler.instance().bus().register(eventListener);
         MinecraftForge.EVENT_BUS.register(new LPChatListener());
         LogisticsPipes.textures.registerBlockIcons(null);
+        LogisticsNewRenderPipe.loadModels();
 
         RecipeManager.registerRecipeClasses();
 

--- a/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
+++ b/src/main/java/logisticspipes/renderer/newpipe/LogisticsNewRenderPipe.java
@@ -305,10 +305,6 @@ public class LogisticsNewRenderPipe {
 
     private static final ResourceLocation BLOCKS = new ResourceLocation("textures/atlas/blocks.png");
 
-    static {
-        LogisticsNewRenderPipe.loadModels();
-    }
-
     public static void loadModels() {
         if (!SimpleServiceLocator.cclProxy.isActivated()) return;
         try {


### PR DESCRIPTION
## Summary
Fixes the models not loading correctly with hodgepodge's async icon loading enabled. It seemed to be working correctly for me but if whoever is looking at this could verify themselves, that would be good.

Does not fix the crash with the crafting sign, that is a different issue.


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
