### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/logisticspipes/network/packets/pipe/ParticleFX.java
+++ b/src/main/java/logisticspipes/network/packets/pipe/ParticleFX.java
@@ -44,7 +44,7 @@ public class ParticleFX extends CoordinatesPacket {
         for (int i = 0; i < nparticles; i++) {
             int particle = data.readByte();
             int amount = data.readInt();
-            particles.add(new ParticleCount(Particles.values()[particle], amount));
+            particles.add(new ParticleCount(Particles.VALUES[particle], amount));
         }
     }
 

--- a/src/main/java/logisticspipes/pipefxhandlers/Particles.java
+++ b/src/main/java/logisticspipes/pipefxhandlers/Particles.java
@@ -9,10 +9,12 @@ public enum Particles {
     VioletParticle,
     OrangeParticle,
     LightGreenParticle,
-    LightRedParticle
+    LightRedParticle;
 
     /*
      * General color arangement: SinkReply: blue Extract: orange Provide/request: violet Use power: gold Render update:
      * green Power status change: red Special cases: white
      */
+
+    public static final Particles[] VALUES = values();
 }

--- a/src/main/java/logisticspipes/pipefxhandlers/Particles.java
+++ b/src/main/java/logisticspipes/pipefxhandlers/Particles.java
@@ -1,6 +1,7 @@
 package logisticspipes.pipefxhandlers;
 
 public enum Particles {
+
     WhiteParticle,
     RedParticle,
     BlueParticle,

--- a/src/main/java/logisticspipes/pipefxhandlers/PipeFXRenderHandler.java
+++ b/src/main/java/logisticspipes/pipefxhandlers/PipeFXRenderHandler.java
@@ -7,7 +7,7 @@ import logisticspipes.proxy.MainProxy;
 
 public class PipeFXRenderHandler {
 
-    private static final ParticleProvider[] particlemap = new ParticleProvider[Particles.values().length];
+    private static final ParticleProvider[] particlemap = new ParticleProvider[Particles.VALUES.length];
 
     public static void spawnGenericParticle(Particles particle, double x, double y, double z, int amount) {
         if (MainProxy.getClientMainWorld() == null) {

--- a/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
@@ -193,7 +193,7 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe
     protected int throttleTime = 20;
     private int throttleTimeLeft = 20 + new Random().nextInt(Configs.LOGISTICS_DETECTION_FREQUENCY);
 
-    private final int[] queuedParticles = new int[Particles.values().length];
+    private final int[] queuedParticles = new int[Particles.VALUES.length];
     private boolean hasQueuedParticles = false;
 
     protected IPipeSign[] signItem = new IPipeSign[6];
@@ -701,7 +701,7 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe
             ArrayList<ParticleCount> tosend = new ArrayList<>(queuedParticles.length);
             for (int i = 0; i < queuedParticles.length; i++) {
                 if (queuedParticles[i] > 0) {
-                    tosend.add(new ParticleCount(Particles.values()[i], queuedParticles[i]));
+                    tosend.add(new ParticleCount(Particles.VALUES[i], queuedParticles[i]));
                 }
             }
             MainProxy.sendPacketToAllWatchingChunk(
@@ -715,7 +715,7 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe
                 for (int i = 0; i < queuedParticles.length; i++) {
                     if (queuedParticles[i] > 0) {
                         PipeFXRenderHandler.spawnGenericParticle(
-                                Particles.values()[i],
+                                Particles.VALUES[i],
                                 getX(),
                                 getY(),
                                 getZ(),

--- a/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/CoreRoutedPipe.java
@@ -714,12 +714,8 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe
             if (Minecraft.isFancyGraphicsEnabled()) {
                 for (int i = 0; i < queuedParticles.length; i++) {
                     if (queuedParticles[i] > 0) {
-                        PipeFXRenderHandler.spawnGenericParticle(
-                                Particles.VALUES[i],
-                                getX(),
-                                getY(),
-                                getZ(),
-                                queuedParticles[i]);
+                        PipeFXRenderHandler
+                                .spawnGenericParticle(Particles.VALUES[i], getX(), getY(), getZ(), queuedParticles[i]);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
