### PR TITLE
Fix fluid insertion pipe buffer

### DIFF
--- a/src/main/java/logisticspipes/pipes/PipeFluidExtractor.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidExtractor.java
@@ -45,19 +45,26 @@ public class PipeFluidExtractor extends PipeFluidInsertion {
         FluidStack contained = ((PipeFluidTransportLogistics) transport).getTankInfo(side)[0].fluid;
         int amountMissing = ((PipeFluidTransportLogistics) transport).getSideCapacity()
                 - (contained != null ? contained.amount : 0);
+
+        FluidStack extracted = container.drain(side.getOpposite(), PipeFluidExtractor.flowRate, false);
+        if (extracted == null || !canReceiveFluid(extracted)) {
+            return;
+        }
+
         if (liquidToExtract[i] < Math.min(PipeFluidExtractor.flowRate, amountMissing)) {
             if (this.useEnergy(PipeFluidExtractor.energyPerFlow)) {
                 liquidToExtract[i] += Math.min(PipeFluidExtractor.flowRate, amountMissing);
             }
         }
-        FluidStack extracted = container
+        extracted = container
                 .drain(side.getOpposite(), Math.min(liquidToExtract[i], PipeFluidExtractor.flowRate), false);
 
-        int inserted = 0;
-        if (extracted != null) {
-            inserted = ((PipeFluidTransportLogistics) transport).fill(side, extracted, true);
-            container.drain(side.getOpposite(), inserted, true);
+        if (extracted == null) {
+            return;
         }
+
+        int inserted = ((PipeFluidTransportLogistics) transport).fill(side, extracted, true);
+        container.drain(side.getOpposite(), inserted, true);
         liquidToExtract[i] -= inserted;
     }
 

--- a/src/main/java/logisticspipes/pipes/PipeFluidInsertion.java
+++ b/src/main/java/logisticspipes/pipes/PipeFluidInsertion.java
@@ -127,4 +127,14 @@ public class PipeFluidInsertion extends FluidRoutedPipe {
     public boolean canReceiveFluid() {
         return true;
     }
+
+    @Override
+    public boolean canReceiveFluid(FluidStack resource) {
+        if (!canReceiveFluid()) {
+            return false;
+        }
+        Pair<Integer, Integer> result = SimpleServiceLocator.logisticsFluidManager
+                .getBestReply(resource, getRouter(), new ArrayList<>());
+        return result != null && result.getValue1() != null && result.getValue1() != 0 && result.getValue2() != 0;
+    }
 }

--- a/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/LogisticsTileGenericPipe.java
@@ -956,6 +956,9 @@ public class LogisticsTileGenericPipe extends TileEntity
 
     @Override
     public FluidTankInfo[] getTankInfo(ForgeDirection from) {
+        if (LogisticsBlockGenericPipe.isValid(pipe) && pipe.transport instanceof IFluidHandler) {
+            return ((IFluidHandler) pipe.transport).getTankInfo(from);
+        }
         return null;
     }
 

--- a/src/main/java/logisticspipes/pipes/basic/fluid/FluidRoutedPipe.java
+++ b/src/main/java/logisticspipes/pipes/basic/fluid/FluidRoutedPipe.java
@@ -239,6 +239,10 @@ public abstract class FluidRoutedPipe extends CoreRoutedPipe {
 
     public abstract boolean canReceiveFluid();
 
+    public boolean canReceiveFluid(FluidStack resource) {
+        return canReceiveFluid();
+    }
+
     public boolean endReached(LPTravelingItemServer arrivingItem, TileEntity tile) {
         if (canInsertToTanks() && MainProxy.isServer(getWorld())) {
             getCacheHolder().trigger(CacheTypes.Inventory);

--- a/src/main/java/logisticspipes/transport/PipeFluidTransportLogistics.java
+++ b/src/main/java/logisticspipes/transport/PipeFluidTransportLogistics.java
@@ -33,7 +33,7 @@ public class PipeFluidTransportLogistics extends PipeTransportLogistics implemen
 
     @Override
     public int fill(ForgeDirection from, FluidStack resource, boolean doFill) {
-        if (from.ordinal() < ForgeDirection.VALID_DIRECTIONS.length && getFluidPipe().canReceiveFluid()) {
+        if (from.ordinal() < ForgeDirection.VALID_DIRECTIONS.length && getFluidPipe().canReceiveFluid(resource)) {
             return sideTanks[from.ordinal()].fill(resource, doFill);
         } else {
             return 0;
@@ -46,7 +46,7 @@ public class PipeFluidTransportLogistics extends PipeTransportLogistics implemen
 
     @Override
     public boolean canFill(ForgeDirection from, Fluid fluid) {
-        return getPipe().isFluidPipe() && getFluidPipe().canReceiveFluid();
+        return getPipe().isFluidPipe() && getFluidPipe().canReceiveFluid(new FluidStack(fluid, 1));
     }
 
     @Override
@@ -76,6 +76,13 @@ public class PipeFluidTransportLogistics extends PipeTransportLogistics implemen
     public FluidTankInfo[] getTankInfo(ForgeDirection from) {
         if (from.ordinal() < ForgeDirection.VALID_DIRECTIONS.length) {
             return new FluidTankInfo[] { new FluidTankInfo(sideTanks[from.ordinal()]) };
+        } else if (from == ForgeDirection.UNKNOWN) {
+            FluidTankInfo[] tanks = new FluidTankInfo[sideTanks.length + 1];
+            for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+                tanks[direction.ordinal()] = new FluidTankInfo(sideTanks[direction.ordinal()]);
+            }
+            tanks[ForgeDirection.UNKNOWN.ordinal()] = new FluidTankInfo(internalTank);
+            return tanks;
         } else {
             return null;
         }


### PR DESCRIPTION
## Summary
The fluid insertion pipe has a hidden buffer that can easily gobble up your precious mB/L's of whatever liquid you just made in the machine your friend felt the need of hooking up to a fluid logistics extractor / insertion pipe.

This buffer is uninspectable using the holo glasses unlike many other inventories, and can easily be blocked by an unroutable fluid until said fluid is routable.

I wont start an argument (here right now) over wether basic fluid pipes should have a "default route" feature 🤔 , ill make another pr for that sometime later.
But in the meanwhile this fix also includes the extraction and insertion pipe not taking liquids that arent routable.

I have not tested this (yet), but will report later. Hence draft status

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
